### PR TITLE
feat: add share token support to drive sharing

### DIFF
--- a/api-go/assets/migrations/003_drive_share_token.down.sql
+++ b/api-go/assets/migrations/003_drive_share_token.down.sql
@@ -1,0 +1,1 @@
+ALTER TABLE drive_shares DROP COLUMN token;

--- a/api-go/assets/migrations/003_drive_share_token.up.sql
+++ b/api-go/assets/migrations/003_drive_share_token.up.sql
@@ -1,0 +1,1 @@
+ALTER TABLE drive_shares ADD COLUMN token TEXT;

--- a/api-go/internal/handlers/drive.go
+++ b/api-go/internal/handlers/drive.go
@@ -368,10 +368,6 @@ func (h *DriveHandler) RevokeShare(r *http.Request, body m.JSON[models.DriveShar
 	return http.StatusNoContent, nil
 }
 
-// sharedItemDTO is the row shape returned by /shares/all. The original public
-// URL is intentionally omitted: we only persist a hash of the token, so the
-// plaintext link is unrecoverable. The frontend surfaces this by offering
-// "revoke + create new link" rather than "copy link".
 type sharedItemDTO struct {
 	ID          int64  `json:"id"`
 	NodeID      int64  `json:"node_id"`
@@ -382,6 +378,7 @@ type sharedItemDTO struct {
 	Name        string `json:"name"`
 	Size        int64  `json:"size"`
 	Path        string `json:"path"`
+	URL         string `json:"url,omitempty"`
 }
 
 type sharesAllQuery struct {
@@ -404,6 +401,9 @@ func (h *DriveHandler) ListAllShares(r *http.Request, q m.Query[sharesAllQuery])
 			Name:        row.Name,
 			Size:        row.Size,
 			Path:        row.Path,
+		}
+		if row.StoredToken.Valid {
+			dto.URL = h.shareURL(r, row.StoredToken.String)
 		}
 		if row.ParentID.Valid {
 			v := row.ParentID.Int64
@@ -498,4 +498,3 @@ func writeDriveErr(w http.ResponseWriter, err error) {
 		http.Error(w, "internal error", http.StatusInternalServerError)
 	}
 }
-

--- a/api-go/internal/handlers/drive_share.go
+++ b/api-go/internal/handlers/drive_share.go
@@ -2,6 +2,10 @@ package handlers
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/subtle"
+	"encoding/hex"
 	"errors"
 	"fmt"
 	"html/template"
@@ -66,12 +70,16 @@ func (h *DriveShareHandler) Landing(w http.ResponseWriter, r *http.Request) {
 	}
 
 	tmpl, _ := template.New("share").Parse(landingHTML)
+	mimeType := node.MimeType()
 	_ = tmpl.Execute(w, map[string]any{
 		"Name":        node.Name,
 		"Size":        humanSize(node.Size.Int64),
 		"HasPassword": share.HasPassword,
 		"Authed":      authed,
 		"Token":       token,
+		"MimeType":    mimeType,
+		"CanVideo":    strings.HasPrefix(mimeType, "video/"),
+		"CanAudio":    strings.HasPrefix(mimeType, "audio/"),
 	})
 }
 
@@ -95,10 +103,15 @@ func (h *DriveShareHandler) Auth(w http.ResponseWriter, r *http.Request) {
 		writeShareErr(w, err)
 		return
 	}
+	cookieValue, ok := sharePasswordCookieValue(share, token)
+	if !ok {
+		writeShareErr(w, services.ErrShareNoPassword)
+		return
+	}
 
 	http.SetCookie(w, &http.Cookie{
 		Name:     sharePasswordCookieName(token),
-		Value:    "1",
+		Value:    cookieValue,
 		Path:     "/shared-files/" + token,
 		HttpOnly: true,
 		SameSite: http.SameSiteLaxMode,
@@ -154,7 +167,11 @@ func (h *DriveShareHandler) passwordOK(r *http.Request, share *models.DriveShare
 		return true
 	}
 	c, err := r.Cookie(sharePasswordCookieName(token))
-	return err == nil && c.Value == "1"
+	if err != nil {
+		return false
+	}
+	want, ok := sharePasswordCookieValue(share, token)
+	return ok && subtle.ConstantTimeCompare([]byte(c.Value), []byte(want)) == 1
 }
 
 // rateLimit allows up to 10 attempts per 5 minutes per (token, IP).
@@ -176,6 +193,15 @@ func (h *DriveShareHandler) rateLimit(ctx context.Context, token, ip string) boo
 func sharePasswordCookieName(token string) string {
 	// Cookie names cannot contain certain chars; token is URL-safe base64.
 	return sharePasswordCookiePrefix + strings.NewReplacer("-", "_").Replace(token[:min(8, len(token))])
+}
+
+func sharePasswordCookieValue(share *models.DriveShare, token string) (string, bool) {
+	if !share.PasswordHash.Valid {
+		return "", false
+	}
+	mac := hmac.New(sha256.New, []byte(share.PasswordHash.String))
+	_, _ = mac.Write([]byte(token))
+	return hex.EncodeToString(mac.Sum(nil)), true
 }
 
 func writeShareErr(w http.ResponseWriter, err error) {
@@ -254,9 +280,12 @@ const landingHTML = `<!doctype html>
   h1 { font-size:18px; margin:0 0 4px; word-break:break-all; }
   p.size { color:#888; margin:0 0 24px; font-size:13px; }
   a.btn, button { display:inline-block; padding:10px 18px; border-radius:8px; background:#111;
-          color:#fff; text-decoration:none; border:0; cursor:pointer; font-size:14px; }
+           color:#fff; text-decoration:none; border:0; cursor:pointer; font-size:14px; }
+  .actions { display:flex; flex-wrap:wrap; gap:10px; align-items:center; }
+  .preview { display:block; width:100%; max-height:60vh; margin:0 0 16px; border-radius:10px; background:#000; }
+  audio.preview { background:transparent; }
   input[type=password] { width:100%; padding:10px 12px; border:1px solid #ddd; border-radius:8px;
-          font-size:14px; box-sizing:border-box; margin-bottom:12px; }
+           font-size:14px; box-sizing:border-box; margin-bottom:12px; }
   form { margin-top:8px; }
   .meta { color:#666; font-size:13px; margin-top:18px; }
 </style>
@@ -271,7 +300,14 @@ const landingHTML = `<!doctype html>
         <button type="submit">Unlock</button>
       </form>
     {{else}}
-      <a class="btn" href="/shared-files/{{.Token}}/download">Download</a>
+      {{if .CanVideo}}
+        <video class="preview" src="/shared-files/{{.Token}}/preview" controls preload="metadata"></video>
+      {{else if .CanAudio}}
+        <audio class="preview" src="/shared-files/{{.Token}}/preview" controls preload="metadata"></audio>
+      {{end}}
+      <div class="actions">
+        <a class="btn" href="/shared-files/{{.Token}}/download">Download</a>
+      </div>
     {{end}}
     <p class="meta">Shared via Mote Drive</p>
   </div>

--- a/api-go/internal/models/drive.go
+++ b/api-go/internal/models/drive.go
@@ -106,6 +106,7 @@ type DriveShare struct {
 	NodeID       int64      `json:"node_id" db:"node_id"`
 	TokenHash    string     `json:"-" db:"token_hash"`
 	TokenPrefix  string     `json:"-" db:"token_prefix"`
+	StoredToken  NullString `json:"-" db:"token"`
 	PasswordHash NullString `json:"-" db:"password_hash"`
 	HasPassword  bool       `json:"has_password"`
 	ExpiresAt    NullInt64  `json:"expires_at" db:"expires_at"`

--- a/api-go/internal/services/drive.go
+++ b/api-go/internal/services/drive.go
@@ -406,10 +406,9 @@ WHERE id IN (SELECT id FROM subtree)`, id, now, batch, now)
 	return tx.Commit()
 }
 
-// Restore restores a node and all of its descendants that share the same delete_batch_id.
-// A batch may contain multiple roots (when SoftDelete was called with several ids);
-// we pre-check sibling-name conflicts for every root so the caller gets a clean
-// ErrDriveNameConflict instead of a low-level UNIQUE constraint error.
+// Restore restores a node and its descendants from trash. Multi-select deletes
+// can put several roots in one delete_batch_id; restoring one trash entry must
+// not resurrect its sibling roots from the same batch.
 func (s *DriveService) Restore(ctx context.Context, id int64) error {
 	n, err := s.FindByID(ctx, id)
 	if err != nil {
@@ -418,35 +417,13 @@ func (s *DriveService) Restore(ctx context.Context, id int64) error {
 	if !n.DeletedAt.Valid {
 		return nil
 	}
-	if !n.DeleteBatchID.Valid {
-		// Unknown batch — restore just this node.
-		_, err := s.db.ExecContext(ctx,
-			`UPDATE drive_nodes SET deleted_at = NULL, delete_batch_id = NULL WHERE id = ?`, id)
-		return err
-	}
-
 	tx, err := s.db.BeginTxx(ctx, nil)
 	if err != nil {
 		return err
 	}
 	defer tx.Rollback()
 
-	// All deleted roots in this batch (i.e. nodes whose parent isn't part of the same batch).
-	var roots []models.DriveNode
-	err = tx.SelectContext(ctx, &roots, `
-SELECT * FROM drive_nodes n
-WHERE n.delete_batch_id = ?
-  AND (
-    n.parent_id IS NULL
-    OR NOT EXISTS (
-      SELECT 1 FROM drive_nodes p
-      WHERE p.id = n.parent_id AND p.delete_batch_id = n.delete_batch_id
-    )
-  )`, n.DeleteBatchID.String)
-	if err != nil {
-		return err
-	}
-	for _, r := range roots {
+	if !n.DeleteBatchID.Valid {
 		var hit int
 		err := tx.QueryRowxContext(ctx, `
 SELECT EXISTS(
@@ -454,17 +431,55 @@ SELECT EXISTS(
   WHERE COALESCE(parent_id, 0) = COALESCE(?, 0)
     AND LOWER(name) = LOWER(?)
     AND deleted_at IS NULL
-)`, r.ParentID, r.Name).Scan(&hit)
+)`, n.ParentID, n.Name).Scan(&hit)
 		if err != nil {
 			return err
 		}
 		if hit == 1 {
 			return ErrDriveNameConflict
 		}
+		if _, err := tx.ExecContext(ctx,
+			`UPDATE drive_nodes SET deleted_at = NULL, delete_batch_id = NULL WHERE id = ?`, id); err != nil {
+			return err
+		}
+		return tx.Commit()
 	}
-	if _, err := tx.ExecContext(ctx,
-		`UPDATE drive_nodes SET deleted_at = NULL, delete_batch_id = NULL
-		 WHERE delete_batch_id = ?`, n.DeleteBatchID.String); err != nil {
+
+	var conflicts int
+	err = tx.QueryRowxContext(ctx, `
+WITH RECURSIVE subtree(id) AS (
+  SELECT id FROM drive_nodes WHERE id = ? AND deleted_at IS NOT NULL
+  UNION ALL
+  SELECT n.id FROM drive_nodes n JOIN subtree s ON n.parent_id = s.id
+  WHERE n.deleted_at IS NOT NULL AND n.delete_batch_id = ?
+)
+SELECT COUNT(*)
+FROM drive_nodes r
+WHERE r.id IN (SELECT id FROM subtree)
+  AND EXISTS (
+    SELECT 1 FROM drive_nodes a
+    WHERE COALESCE(a.parent_id, 0) = COALESCE(r.parent_id, 0)
+      AND LOWER(a.name) = LOWER(r.name)
+      AND a.deleted_at IS NULL
+      AND a.id NOT IN (SELECT id FROM subtree)
+  )`, id, n.DeleteBatchID.String).Scan(&conflicts)
+	if err != nil {
+		return err
+	}
+	if conflicts > 0 {
+		return ErrDriveNameConflict
+	}
+
+	if _, err := tx.ExecContext(ctx, `
+WITH RECURSIVE subtree(id) AS (
+  SELECT id FROM drive_nodes WHERE id = ? AND deleted_at IS NOT NULL
+  UNION ALL
+  SELECT n.id FROM drive_nodes n JOIN subtree s ON n.parent_id = s.id
+  WHERE n.deleted_at IS NOT NULL AND n.delete_batch_id = ?
+)
+UPDATE drive_nodes
+SET deleted_at = NULL, delete_batch_id = NULL
+WHERE id IN (SELECT id FROM subtree)`, id, n.DeleteBatchID.String); err != nil {
 		return err
 	}
 	return tx.Commit()

--- a/api-go/internal/services/drive_share.go
+++ b/api-go/internal/services/drive_share.go
@@ -35,7 +35,8 @@ func NewDriveShareService(db *sqlx.DB, drive *DriveService) *DriveShareService {
 	return &DriveShareService{db: db, drive: drive}
 }
 
-// Create issues a new share. The plaintext token is returned only once via DriveShare.Token.
+// Create issues a new share. The plaintext token is persisted so authenticated
+// owners can view/copy existing share links later.
 func (s *DriveShareService) Create(
 	ctx context.Context, nodeID int64, password *string, expiresAt *int64,
 ) (*models.DriveShare, error) {
@@ -71,9 +72,9 @@ func (s *DriveShareService) Create(
 	now := time.Now().UnixMilli()
 	var id int64
 	err = s.db.QueryRowxContext(ctx, `
-INSERT INTO drive_shares (node_id, token_hash, token_prefix, password_hash, expires_at, created_at)
-VALUES (?, ?, ?, ?, ?, ?) RETURNING id`,
-		nodeID, hash, prefix, pwHash, exp, now).Scan(&id)
+INSERT INTO drive_shares (node_id, token_hash, token_prefix, token, password_hash, expires_at, created_at)
+VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id`,
+		nodeID, hash, prefix, token, pwHash, exp, now).Scan(&id)
 	if err != nil {
 		return nil, err
 	}

--- a/api-go/internal/services/drive_test.go
+++ b/api-go/internal/services/drive_test.go
@@ -47,6 +47,7 @@ CREATE TABLE drive_shares (
   node_id INTEGER NOT NULL REFERENCES drive_nodes(id) ON DELETE CASCADE,
   token_hash TEXT NOT NULL UNIQUE,
   token_prefix TEXT NOT NULL,
+  token TEXT,
   password_hash TEXT,
   expires_at INTEGER,
   created_at INTEGER NOT NULL
@@ -246,296 +247,299 @@ func TestDrive_SearchPopulatesPath(t *testing.T) {
 
 // List should populate ShareCount with the number of currently-active shares.
 func TestDrive_ListPopulatesShareCount(t *testing.T) {
-db, svc := setupDriveDB(t)
-ctx := context.Background()
-parent, _ := svc.CreateFolder(ctx, nil, "p")
+	db, svc := setupDriveDB(t)
+	ctx := context.Background()
+	parent, _ := svc.CreateFolder(ctx, nil, "p")
 
-blob := filepath.Join("drive", "y.txt")
-_ = os.MkdirAll(filepath.Dir(svc.BlobAbsPath(blob)), 0755)
-_ = os.WriteFile(svc.BlobAbsPath(blob), []byte("hi"), 0644)
+	blob := filepath.Join("drive", "y.txt")
+	_ = os.MkdirAll(filepath.Dir(svc.BlobAbsPath(blob)), 0755)
+	_ = os.WriteFile(svc.BlobAbsPath(blob), []byte("hi"), 0644)
 
-f, err := svc.CreateFileNode(ctx, &parent.ID, "doc.txt", blob, "", 2)
-if err != nil {
-t.Fatal(err)
-}
+	f, err := svc.CreateFileNode(ctx, &parent.ID, "doc.txt", blob, "", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-now := int64(1_700_000_000_000)
-// 1 active (no expiry) + 1 active (future) + 1 expired
-_, _ = db.Exec(
-`INSERT INTO drive_shares (node_id, token_hash, token_prefix, expires_at, created_at) VALUES
+	now := int64(1_700_000_000_000)
+	// 1 active (no expiry) + 1 active (future) + 1 expired
+	_, _ = db.Exec(
+		`INSERT INTO drive_shares (node_id, token_hash, token_prefix, expires_at, created_at) VALUES
  (?, ?, ?, NULL, ?),
  (?, ?, ?, ?, ?),
  (?, ?, ?, ?, ?)`,
-f.ID, "h1", "h1", now,
-f.ID, "h2", "h2", time.Now().Add(time.Hour).UnixMilli(), now,
-f.ID, "h3", "h3", time.Now().Add(-time.Hour).UnixMilli(), now,
-)
+		f.ID, "h1", "h1", now,
+		f.ID, "h2", "h2", time.Now().Add(time.Hour).UnixMilli(), now,
+		f.ID, "h3", "h3", time.Now().Add(-time.Hour).UnixMilli(), now,
+	)
 
-out, err := svc.List(ctx, &parent.ID, nil, "", "")
-if err != nil {
-t.Fatal(err)
-}
-var got int
-for _, n := range out {
-if n.ID == f.ID {
-got = n.ShareCount
-}
-}
-if got != 2 {
-t.Fatalf("ShareCount = %d, want 2", got)
-}
+	out, err := svc.List(ctx, &parent.ID, nil, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var got int
+	for _, n := range out {
+		if n.ID == f.ID {
+			got = n.ShareCount
+		}
+	}
+	if got != 2 {
+		t.Fatalf("ShareCount = %d, want 2", got)
+	}
 }
 
 // Hard-deleting a node should cascade-delete its drive_shares rows.
 func TestDrive_PurgeCascadesShares(t *testing.T) {
-db, svc := setupDriveDB(t)
-ctx := context.Background()
-parent, _ := svc.CreateFolder(ctx, nil, "p")
+	db, svc := setupDriveDB(t)
+	ctx := context.Background()
+	parent, _ := svc.CreateFolder(ctx, nil, "p")
 
-blob := filepath.Join("drive", "z.txt")
-_ = os.MkdirAll(filepath.Dir(svc.BlobAbsPath(blob)), 0755)
-_ = os.WriteFile(svc.BlobAbsPath(blob), []byte("hi"), 0644)
-f, err := svc.CreateFileNode(ctx, &parent.ID, "z.txt", blob, "", 2)
-if err != nil {
-t.Fatal(err)
-}
-if _, err := db.Exec(
-`INSERT INTO drive_shares (node_id, token_hash, token_prefix, expires_at, created_at)
+	blob := filepath.Join("drive", "z.txt")
+	_ = os.MkdirAll(filepath.Dir(svc.BlobAbsPath(blob)), 0755)
+	_ = os.WriteFile(svc.BlobAbsPath(blob), []byte("hi"), 0644)
+	f, err := svc.CreateFileNode(ctx, &parent.ID, "z.txt", blob, "", 2)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := db.Exec(
+		`INSERT INTO drive_shares (node_id, token_hash, token_prefix, expires_at, created_at)
  VALUES (?, 'tk', 'tk', NULL, 1)`, f.ID); err != nil {
-t.Fatal(err)
-}
+		t.Fatal(err)
+	}
 
-// Purge the parent folder; child file row + its share should be gone.
-if err := svc.Purge(ctx, []int64{parent.ID}); err != nil {
-t.Fatal(err)
-}
-var n int
-_ = db.Get(&n, `SELECT COUNT(*) FROM drive_shares`)
-if n != 0 {
-t.Fatalf("expected drive_shares empty after purge, got %d rows", n)
-}
+	// Purge the parent folder; child file row + its share should be gone.
+	if err := svc.Purge(ctx, []int64{parent.ID}); err != nil {
+		t.Fatal(err)
+	}
+	var n int
+	_ = db.Get(&n, `SELECT COUNT(*) FROM drive_shares`)
+	if n != 0 {
+		t.Fatalf("expected drive_shares empty after purge, got %d rows", n)
+	}
 }
 
 // ListAll returns every share joined with the file's name + path; expired
 // rows are filtered unless includeExpired is true. Shares whose underlying
 // file is soft-deleted are excluded.
 func TestDriveShare_ListAll(t *testing.T) {
-db, svc := setupDriveDB(t)
-ctx := context.Background()
-share := NewDriveShareService(db, svc)
+	db, svc := setupDriveDB(t)
+	ctx := context.Background()
+	share := NewDriveShareService(db, svc)
 
-parent, _ := svc.CreateFolder(ctx, nil, "outer")
-inner, _ := svc.CreateFolder(ctx, &parent.ID, "inner")
+	parent, _ := svc.CreateFolder(ctx, nil, "outer")
+	inner, _ := svc.CreateFolder(ctx, &parent.ID, "inner")
 
-mk := func(parentID *int64, name string) *models.DriveNode {
-blob := filepath.Join("drive", name)
-_ = os.MkdirAll(filepath.Dir(svc.BlobAbsPath(blob)), 0755)
-_ = os.WriteFile(svc.BlobAbsPath(blob), []byte("x"), 0644)
-f, err := svc.CreateFileNode(ctx, parentID, name, blob, "", 1)
-if err != nil {
-t.Fatal(err)
-}
-return f
-}
-a := mk(&inner.ID, "a.txt")
-b := mk(nil, "b.txt")
-c := mk(nil, "c.txt") // will be soft-deleted
+	mk := func(parentID *int64, name string) *models.DriveNode {
+		blob := filepath.Join("drive", name)
+		_ = os.MkdirAll(filepath.Dir(svc.BlobAbsPath(blob)), 0755)
+		_ = os.WriteFile(svc.BlobAbsPath(blob), []byte("x"), 0644)
+		f, err := svc.CreateFileNode(ctx, parentID, name, blob, "", 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return f
+	}
+	a := mk(&inner.ID, "a.txt")
+	b := mk(nil, "b.txt")
+	c := mk(nil, "c.txt") // will be soft-deleted
 
-now := int64(1_700_000_000_000)
-future := time.Now().Add(time.Hour).UnixMilli()
-past := time.Now().Add(-time.Hour).UnixMilli()
-_, err := db.Exec(`INSERT INTO drive_shares
+	now := int64(1_700_000_000_000)
+	future := time.Now().Add(time.Hour).UnixMilli()
+	past := time.Now().Add(-time.Hour).UnixMilli()
+	_, err := db.Exec(`INSERT INTO drive_shares
 (node_id, token_hash, token_prefix, expires_at, created_at) VALUES
 (?, 'h1', 'h1', NULL,    ?),
 (?, 'h2', 'h2', ?,        ?),
 (?, 'h3', 'h3', ?,        ?),
 (?, 'h4', 'h4', NULL,    ?)`,
-a.ID, now,
-b.ID, future, now+1,
-b.ID, past, now+2, // expired
-c.ID, now+3,       // file will be soft-deleted
-)
-if err != nil {
-t.Fatal(err)
-}
-if err := svc.SoftDelete(ctx, []int64{c.ID}); err != nil {
-t.Fatal(err)
-}
+		a.ID, now,
+		b.ID, future, now+1,
+		b.ID, past, now+2, // expired
+		c.ID, now+3, // file will be soft-deleted
+	)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := svc.SoftDelete(ctx, []int64{c.ID}); err != nil {
+		t.Fatal(err)
+	}
 
-rows, err := share.ListAll(ctx, false)
-if err != nil {
-t.Fatal(err)
-}
-if len(rows) != 2 {
-t.Fatalf("active rows = %d, want 2 (got %+v)", len(rows), rows)
-}
-// rows are ordered by created_at DESC: b (future) first, a second
-if rows[0].Name != "b.txt" || rows[0].Path != "" {
-t.Errorf("row0 = %+v", rows[0])
-}
-if rows[1].Name != "a.txt" || rows[1].Path != "outer/inner" {
-t.Errorf("row1 = %+v", rows[1])
-}
+	rows, err := share.ListAll(ctx, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 2 {
+		t.Fatalf("active rows = %d, want 2 (got %+v)", len(rows), rows)
+	}
+	// rows are ordered by created_at DESC: b (future) first, a second
+	if rows[0].Name != "b.txt" || rows[0].Path != "" {
+		t.Errorf("row0 = %+v", rows[0])
+	}
+	if rows[1].Name != "a.txt" || rows[1].Path != "outer/inner" {
+		t.Errorf("row1 = %+v", rows[1])
+	}
 
-all, err := share.ListAll(ctx, true)
-if err != nil {
-t.Fatal(err)
-}
-if len(all) != 3 { // includes expired b-share, excludes c (deleted file)
-t.Fatalf("all rows = %d, want 3", len(all))
-}
+	all, err := share.ListAll(ctx, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 3 { // includes expired b-share, excludes c (deleted file)
+		t.Fatalf("all rows = %d, want 3", len(all))
+	}
 }
 
 // PurgeExpired removes only rows with expires_at <= now.
 func TestDriveShare_PurgeExpired(t *testing.T) {
-db, svc := setupDriveDB(t)
-ctx := context.Background()
-share := NewDriveShareService(db, svc)
+	db, svc := setupDriveDB(t)
+	ctx := context.Background()
+	share := NewDriveShareService(db, svc)
 
-blob := filepath.Join("drive", "p.txt")
-_ = os.MkdirAll(filepath.Dir(svc.BlobAbsPath(blob)), 0755)
-_ = os.WriteFile(svc.BlobAbsPath(blob), []byte("x"), 0644)
-f, err := svc.CreateFileNode(ctx, nil, "p.txt", blob, "", 1)
-if err != nil {
-t.Fatal(err)
-}
+	blob := filepath.Join("drive", "p.txt")
+	_ = os.MkdirAll(filepath.Dir(svc.BlobAbsPath(blob)), 0755)
+	_ = os.WriteFile(svc.BlobAbsPath(blob), []byte("x"), 0644)
+	f, err := svc.CreateFileNode(ctx, nil, "p.txt", blob, "", 1)
+	if err != nil {
+		t.Fatal(err)
+	}
 
-now := time.Now().UnixMilli()
-_, _ = db.Exec(`INSERT INTO drive_shares
+	now := time.Now().UnixMilli()
+	_, _ = db.Exec(`INSERT INTO drive_shares
 (node_id, token_hash, token_prefix, expires_at, created_at) VALUES
 (?, 'a', 'a', NULL,    ?),
 (?, 'b', 'b', ?,        ?),
 (?, 'c', 'c', ?,        ?)`,
-f.ID, now,
-f.ID, now-1, now,
-f.ID, now+3600_000, now,
-)
+		f.ID, now,
+		f.ID, now-1, now,
+		f.ID, now+3600_000, now,
+	)
 
-n, err := share.PurgeExpired(ctx)
-if err != nil {
-t.Fatal(err)
-}
-if n != 1 {
-t.Fatalf("purged = %d, want 1", n)
-}
-var left int
-_ = db.Get(&left, `SELECT COUNT(*) FROM drive_shares`)
-if left != 2 {
-t.Fatalf("remaining = %d, want 2", left)
-}
+	n, err := share.PurgeExpired(ctx)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if n != 1 {
+		t.Fatalf("purged = %d, want 1", n)
+	}
+	var left int
+	_ = db.Get(&left, `SELECT COUNT(*) FROM drive_shares`)
+	if left != 2 {
+		t.Fatalf("remaining = %d, want 2", left)
+	}
 }
 
 // LIKE wildcard escape: a query of "_" must not match every name.
 func TestDrive_SearchEscapesLikeWildcards(t *testing.T) {
-_, svc := setupDriveDB(t)
-ctx := context.Background()
+	_, svc := setupDriveDB(t)
+	ctx := context.Background()
 
-if _, err := svc.CreateFolder(ctx, nil, "alpha"); err != nil {
-t.Fatal(err)
-}
-if _, err := svc.CreateFolder(ctx, nil, "with_underscore"); err != nil {
-t.Fatal(err)
-}
+	if _, err := svc.CreateFolder(ctx, nil, "alpha"); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.CreateFolder(ctx, nil, "with_underscore"); err != nil {
+		t.Fatal(err)
+	}
 
-q := "_"
-rows, err := svc.List(ctx, nil, &q, "name", "asc")
-if err != nil {
-t.Fatal(err)
-}
-if len(rows) != 1 || rows[0].Name != "with_underscore" {
-t.Fatalf("expected 1 underscore match, got %+v", rows)
-}
+	q := "_"
+	rows, err := svc.List(ctx, nil, &q, "name", "asc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 1 || rows[0].Name != "with_underscore" {
+		t.Fatalf("expected 1 underscore match, got %+v", rows)
+	}
 
-q = "%"
-rows, err = svc.List(ctx, nil, &q, "name", "asc")
-if err != nil {
-t.Fatal(err)
-}
-if len(rows) != 0 {
-t.Fatalf("percent should match nothing, got %+v", rows)
-}
+	q = "%"
+	rows, err = svc.List(ctx, nil, &q, "name", "asc")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(rows) != 0 {
+		t.Fatalf("percent should match nothing, got %+v", rows)
+	}
 }
 
 // Search does not require parentID to be valid.
 func TestDrive_SearchIgnoresParent(t *testing.T) {
-_, svc := setupDriveDB(t)
-ctx := context.Background()
+	_, svc := setupDriveDB(t)
+	ctx := context.Background()
 
-if _, err := svc.CreateFolder(ctx, nil, "alpha"); err != nil {
-t.Fatal(err)
-}
-bogus := int64(9999)
-q := "alpha"
-rows, err := svc.List(ctx, &bogus, &q, "name", "asc")
-if err != nil {
-t.Fatalf("search with stale parent should not error: %v", err)
-}
-if len(rows) != 1 {
-t.Fatalf("got %d rows", len(rows))
-}
-}
-
-// Restore must check name conflicts for *every* root in the batch, and surface
-// ErrDriveNameConflict instead of a low-level UNIQUE error.
-func TestDrive_RestoreMultiRootConflict(t *testing.T) {
-_, svc := setupDriveDB(t)
-ctx := context.Background()
-
-a, _ := svc.CreateFolder(ctx, nil, "a")
-b, _ := svc.CreateFolder(ctx, nil, "b")
-if err := svc.SoftDelete(ctx, []int64{a.ID, b.ID}); err != nil {
-t.Fatal(err)
-}
-// Recreate "a" so restoring the batch will collide on b's sibling? No —
-// the conflict must be on one of the deleted roots' own name. Recreate "a":
-if _, err := svc.CreateFolder(ctx, nil, "a"); err != nil {
-t.Fatal(err)
+	if _, err := svc.CreateFolder(ctx, nil, "alpha"); err != nil {
+		t.Fatal(err)
+	}
+	bogus := int64(9999)
+	q := "alpha"
+	rows, err := svc.List(ctx, &bogus, &q, "name", "asc")
+	if err != nil {
+		t.Fatalf("search with stale parent should not error: %v", err)
+	}
+	if len(rows) != 1 {
+		t.Fatalf("got %d rows", len(rows))
+	}
 }
 
-// Even though the user asks to restore via b.ID (the non-conflicting root),
-// the whole batch would resurrect both, so the conflict on "a" must be caught.
-err := svc.Restore(ctx, b.ID)
-if !errors.Is(err, ErrDriveNameConflict) {
-t.Fatalf("expected ErrDriveNameConflict, got %v", err)
-}
+// Restoring one trash root from a multi-select delete must not restore or be
+// blocked by sibling roots from the same delete batch.
+func TestDrive_RestoreMultiRootOnlyRestoresRequestedRoot(t *testing.T) {
+	_, svc := setupDriveDB(t)
+	ctx := context.Background()
+
+	a, _ := svc.CreateFolder(ctx, nil, "a")
+	b, _ := svc.CreateFolder(ctx, nil, "b")
+	if err := svc.SoftDelete(ctx, []int64{a.ID, b.ID}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := svc.CreateFolder(ctx, nil, "a"); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := svc.Restore(ctx, b.ID); err != nil {
+		t.Fatalf("restore b: %v", err)
+	}
+	gotB, _ := svc.FindByID(ctx, b.ID)
+	if gotB.DeletedAt.Valid {
+		t.Fatal("requested root b is still deleted")
+	}
+	gotA, _ := svc.FindByID(ctx, a.ID)
+	if !gotA.DeletedAt.Valid {
+		t.Fatal("sibling root a should remain in trash")
+	}
 }
 
 // AutoRename picks max(N)+1 in a single pass (skips deleted and case-insens).
 func TestDrive_AutoRenameSkipsDeleted(t *testing.T) {
-_, svc := setupDriveDB(t)
-ctx := context.Background()
-parent, _ := svc.CreateFolder(ctx, nil, "p")
+	_, svc := setupDriveDB(t)
+	ctx := context.Background()
+	parent, _ := svc.CreateFolder(ctx, nil, "p")
 
-mk := func(name string) int64 {
-blob := filepath.Join("drive", name)
-_ = os.MkdirAll(filepath.Dir(svc.BlobAbsPath(blob)), 0755)
-_ = os.WriteFile(svc.BlobAbsPath(blob), []byte("x"), 0644)
-n, err := svc.CreateFileNode(ctx, &parent.ID, name, blob, "", 1)
-if err != nil {
-t.Fatal(err)
-}
-return n.ID
-}
-mk("report.pdf")
-mk("report (1).pdf")
-id3 := mk("report (3).pdf")
+	mk := func(name string) int64 {
+		blob := filepath.Join("drive", name)
+		_ = os.MkdirAll(filepath.Dir(svc.BlobAbsPath(blob)), 0755)
+		_ = os.WriteFile(svc.BlobAbsPath(blob), []byte("x"), 0644)
+		n, err := svc.CreateFileNode(ctx, &parent.ID, name, blob, "", 1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		return n.ID
+	}
+	mk("report.pdf")
+	mk("report (1).pdf")
+	id3 := mk("report (3).pdf")
 
-cand, err := svc.AutoRename(ctx, &parent.ID, "report.pdf")
-if err != nil {
-t.Fatal(err)
-}
-if cand != "report (4).pdf" {
-t.Fatalf("expected report (4).pdf, got %q", cand)
-}
-// Soft-delete the (3) and try again — should drop back to (2).
-if err := svc.SoftDelete(ctx, []int64{id3}); err != nil {
-t.Fatal(err)
-}
-cand, err = svc.AutoRename(ctx, &parent.ID, "report.pdf")
-if err != nil {
-t.Fatal(err)
-}
-if cand != "report (2).pdf" {
-t.Fatalf("after soft-delete expected report (2).pdf, got %q", cand)
-}
+	cand, err := svc.AutoRename(ctx, &parent.ID, "report.pdf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cand != "report (4).pdf" {
+		t.Fatalf("expected report (4).pdf, got %q", cand)
+	}
+	// Soft-delete the (3) and try again — should drop back to (2).
+	if err := svc.SoftDelete(ctx, []int64{id3}); err != nil {
+		t.Fatal(err)
+	}
+	cand, err = svc.AutoRename(ctx, &parent.ID, "report.pdf")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if cand != "report (2).pdf" {
+		t.Fatalf("after soft-delete expected report (2).pdf, got %q", cand)
+	}
 }

--- a/api-go/internal/services/drive_upload_test.go
+++ b/api-go/internal/services/drive_upload_test.go
@@ -63,6 +63,7 @@ CREATE TABLE drive_shares (
   node_id INTEGER NOT NULL REFERENCES drive_nodes(id) ON DELETE CASCADE,
   token_hash TEXT NOT NULL UNIQUE,
   token_prefix TEXT NOT NULL,
+  token TEXT,
   password_hash TEXT,
   expires_at INTEGER,
   created_at INTEGER NOT NULL
@@ -290,6 +291,9 @@ func TestShare_CreateAndResolve(t *testing.T) {
 	if sh.Token == "" {
 		t.Fatal("token not returned")
 	}
+	if !sh.StoredToken.Valid || sh.StoredToken.String != sh.Token {
+		t.Fatal("token should be stored for owner-visible share links")
+	}
 	if sh.HasPassword {
 		t.Fatal("should not require password")
 	}
@@ -402,43 +406,43 @@ func TestShare_ListByNode(t *testing.T) {
 // Complete must re-validate the parent folder; if it was soft-deleted between
 // Init and Complete, we should refuse rather than orphan the file.
 func TestUpload_CompleteRefusesDeletedParent(t *testing.T) {
-_, drive, upload, _ := setupDriveFullDB(t)
-ctx := context.Background()
-parent, _ := drive.CreateFolder(ctx, nil, "p")
+	_, drive, upload, _ := setupDriveFullDB(t)
+	ctx := context.Background()
+	parent, _ := drive.CreateFolder(ctx, nil, "p")
 
-body := []byte("payload")
-u, err := upload.Init(ctx, models.DriveUploadInitRequest{
-ParentID: &parent.ID, Name: "x.txt", Size: int64(len(body)), ChunkSize: 1 << 20,
-})
-if err != nil {
-t.Fatal(err)
-}
-if err := upload.PutChunk(ctx, u.ID, 0, bytes.NewReader(body)); err != nil {
-t.Fatal(err)
-}
-// Soft-delete the parent before completing.
-if err := drive.SoftDelete(ctx, []int64{parent.ID}); err != nil {
-t.Fatal(err)
-}
-if _, err := upload.Complete(ctx, u.ID, "ask"); !errors.Is(err, ErrDriveNotFound) {
-t.Fatalf("expected ErrDriveNotFound, got %v", err)
-}
+	body := []byte("payload")
+	u, err := upload.Init(ctx, models.DriveUploadInitRequest{
+		ParentID: &parent.ID, Name: "x.txt", Size: int64(len(body)), ChunkSize: 1 << 20,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := upload.PutChunk(ctx, u.ID, 0, bytes.NewReader(body)); err != nil {
+		t.Fatal(err)
+	}
+	// Soft-delete the parent before completing.
+	if err := drive.SoftDelete(ctx, []int64{parent.ID}); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := upload.Complete(ctx, u.ID, "ask"); !errors.Is(err, ErrDriveNotFound) {
+		t.Fatalf("expected ErrDriveNotFound, got %v", err)
+	}
 }
 
 // Concurrent chunk uploads of the same session must not deadlock with
 // SQLITE_BUSY. The test uses real disk + real connection pool to expose
 // the deferred-tx upgrade hazard fixed by BEGIN IMMEDIATE in PutChunk.
 func TestUpload_ConcurrentChunksNoBusy(t *testing.T) {
-t.Helper()
-dsn := "file:" + t.Name() + "?mode=memory&cache=shared&_pragma=foreign_keys(1)&_pragma=busy_timeout(2000)&_pragma=journal_mode(WAL)"
-db, err := sqlx.Open("sqlite", dsn)
-if err != nil {
-t.Fatalf("open: %v", err)
-}
-t.Cleanup(func() { db.Close() })
-db.SetMaxOpenConns(8)
+	t.Helper()
+	dsn := "file:" + t.Name() + "?mode=memory&cache=shared&_pragma=foreign_keys(1)&_pragma=busy_timeout(2000)&_pragma=journal_mode(WAL)"
+	db, err := sqlx.Open("sqlite", dsn)
+	if err != nil {
+		t.Fatalf("open: %v", err)
+	}
+	t.Cleanup(func() { db.Close() })
+	db.SetMaxOpenConns(8)
 
-schema := `
+	schema := `
 CREATE TABLE drive_nodes (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   parent_id INTEGER REFERENCES drive_nodes(id) ON DELETE CASCADE,
@@ -460,44 +464,44 @@ CREATE TABLE drive_shares (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
   node_id INTEGER NOT NULL REFERENCES drive_nodes(id) ON DELETE CASCADE,
   token_hash TEXT NOT NULL UNIQUE, token_prefix TEXT NOT NULL,
-  password_hash TEXT, expires_at INTEGER, created_at INTEGER NOT NULL
+  token TEXT, password_hash TEXT, expires_at INTEGER, created_at INTEGER NOT NULL
 );`
-if _, err := db.Exec(schema); err != nil {
-t.Fatalf("schema: %v", err)
-}
-tmp := t.TempDir()
-cfg := &config.UploadConfig{BaseURL: "/uploads", BasePath: tmp}
-drive := NewDriveService(db, cfg)
-upload := NewDriveUploadService(db, drive, cfg)
+	if _, err := db.Exec(schema); err != nil {
+		t.Fatalf("schema: %v", err)
+	}
+	tmp := t.TempDir()
+	cfg := &config.UploadConfig{BaseURL: "/uploads", BasePath: tmp}
+	drive := NewDriveService(db, cfg)
+	upload := NewDriveUploadService(db, drive, cfg)
 
-ctx := context.Background()
-const chunk = int64(1 << 20)
-const n = 16
-body := bytes.Repeat([]byte{'x'}, int(chunk)*n)
-u, err := upload.Init(ctx, models.DriveUploadInitRequest{
-Name: "concur.bin", Size: int64(len(body)), ChunkSize: chunk,
-})
-if err != nil {
-t.Fatal(err)
-}
+	ctx := context.Background()
+	const chunk = int64(1 << 20)
+	const n = 16
+	body := bytes.Repeat([]byte{'x'}, int(chunk)*n)
+	u, err := upload.Init(ctx, models.DriveUploadInitRequest{
+		Name: "concur.bin", Size: int64(len(body)), ChunkSize: chunk,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
 
-errs := make(chan error, n)
-for i := 0; i < n; i++ {
-i := i
-go func() {
-start := int64(i) * chunk
-end := start + chunk
-errs <- upload.PutChunk(ctx, u.ID, i, bytes.NewReader(body[start:end]))
-}()
-}
-for i := 0; i < n; i++ {
-if err := <-errs; err != nil {
-t.Fatalf("chunk %d: %v", i, err)
-}
-}
-// After all chunks land, complete should succeed.
-if _, err := upload.Complete(ctx, u.ID, "ask"); err != nil {
-t.Fatalf("complete: %v", err)
-}
-_ = strings.ToUpper
+	errs := make(chan error, n)
+	for i := 0; i < n; i++ {
+		i := i
+		go func() {
+			start := int64(i) * chunk
+			end := start + chunk
+			errs <- upload.PutChunk(ctx, u.ID, i, bytes.NewReader(body[start:end]))
+		}()
+	}
+	for i := 0; i < n; i++ {
+		if err := <-errs; err != nil {
+			t.Fatalf("chunk %d: %v", i, err)
+		}
+	}
+	// After all chunks land, complete should succeed.
+	if _, err := upload.Complete(ctx, u.ID, "ask"); err != nil {
+		t.Fatalf("complete: %v", err)
+	}
+	_ = strings.ToUpper
 }

--- a/api-kt/src/main/kotlin/site/daydream/mote/controller/DriveController.kt
+++ b/api-kt/src/main/kotlin/site/daydream/mote/controller/DriveController.kt
@@ -204,7 +204,10 @@ class DriveController(
         shareService.listByNode(id).map { toShareDto(it, null, null) }
 
     @GetMapping("/shares/all")
-    fun listAllShares(@RequestParam(name = "include_expired", defaultValue = "false") includeExpired: Boolean):
+    fun listAllShares(
+        @RequestParam(name = "include_expired", defaultValue = "false") includeExpired: Boolean,
+        request: HttpServletRequest,
+    ):
             List<DriveSharedItemDto> = shareService.listAll(includeExpired).map {
         DriveSharedItemDto(
             id = it.share.id,
@@ -216,6 +219,7 @@ class DriveController(
             name = it.name,
             size = it.size,
             path = it.path,
+            url = it.share.storedToken?.let { token -> shareUrl(request, token) },
         )
     }
 

--- a/api-kt/src/main/kotlin/site/daydream/mote/controller/DriveSharePageController.kt
+++ b/api-kt/src/main/kotlin/site/daydream/mote/controller/DriveSharePageController.kt
@@ -17,6 +17,8 @@ import site.daydream.mote.service.RedisService
 import java.io.File
 import java.net.URLEncoder
 import java.nio.charset.StandardCharsets
+import javax.crypto.Mac
+import javax.crypto.spec.SecretKeySpec
 
 private const val COOKIE_PREFIX = "drive_share_pw_"
 
@@ -51,6 +53,7 @@ class DriveSharePageController(
         val html = renderLanding(
             name = node.name,
             size = humanSize(node.size ?: 0),
+            mimeType = node.mimeType ?: "application/octet-stream",
             hasPassword = !share.passwordHash.isNullOrEmpty(),
             authed = authed,
             token = token,
@@ -70,8 +73,9 @@ class DriveSharePageController(
         }
         val (share, _) = shareService.resolve(token)
         shareService.verifyPassword(share, password ?: "")
+        val cookieValue = cookieValue(share, token)
 
-        val cookie = Cookie(cookieName(token), "1").apply {
+        val cookie = Cookie(cookieName(token), cookieValue).apply {
             path = "/shared-files/$token"
             isHttpOnly = true
             maxAge = 60 * 60 * 24
@@ -115,7 +119,14 @@ class DriveSharePageController(
     private fun passwordOk(req: HttpServletRequest, share: DriveShare, token: String): Boolean {
         if (share.passwordHash.isNullOrEmpty()) return true
         val c = req.cookies?.firstOrNull { it.name == cookieName(token) } ?: return false
-        return c.value == "1"
+        return constantTimeEquals(c.value, cookieValue(share, token))
+    }
+
+    private fun cookieValue(share: DriveShare, token: String): String {
+        val key = share.passwordHash ?: throw AuthenticationException("share has no password")
+        val mac = Mac.getInstance("HmacSHA256")
+        mac.init(SecretKeySpec(key.toByteArray(StandardCharsets.UTF_8), "HmacSHA256"))
+        return mac.doFinal(token.toByteArray(StandardCharsets.UTF_8)).toHex()
     }
 
     private fun cookieName(token: String): String {
@@ -163,7 +174,23 @@ class DriveSharePageController(
             s.replace("&", "&amp;").replace("<", "&lt;").replace(">", "&gt;")
                 .replace("\"", "&quot;").replace("'", "&#39;")
 
-        fun renderLanding(name: String, size: String, hasPassword: Boolean, authed: Boolean, token: String): String {
+        private fun ByteArray.toHex(): String = joinToString("") { "%02x".format(it.toInt() and 0xff) }
+
+        private fun constantTimeEquals(a: String, b: String): Boolean {
+            if (a.length != b.length) return false
+            var diff = 0
+            for (i in a.indices) diff = diff or (a[i].code xor b[i].code)
+            return diff == 0
+        }
+
+        fun renderLanding(
+            name: String,
+            size: String,
+            mimeType: String,
+            hasPassword: Boolean,
+            authed: Boolean,
+            token: String,
+        ): String {
             val n = esc(name); val s = esc(size); val t = esc(token)
             val cta = if (hasPassword && !authed) {
                 """<form method="post" action="/shared-files/$t/auth">
@@ -171,7 +198,14 @@ class DriveSharePageController(
                     <button type="submit">Unlock</button>
                   </form>"""
             } else {
-                """<a class="btn" href="/shared-files/$t/download">Download</a>"""
+                val preview = when {
+                    mimeType.startsWith("video/") ->
+                        """<video class="preview" src="/shared-files/$t/preview" controls preload="metadata"></video>"""
+                    mimeType.startsWith("audio/") ->
+                        """<audio class="preview" src="/shared-files/$t/preview" controls preload="metadata"></audio>"""
+                    else -> ""
+                }
+                """$preview<div class="actions"><a class="btn" href="/shared-files/$t/download">Download</a></div>"""
             }
             return """<!doctype html>
 <html lang="en"><head><meta charset="utf-8">
@@ -186,9 +220,12 @@ class DriveSharePageController(
   h1 { font-size:18px; margin:0 0 4px; word-break:break-all; }
   p.size { color:#888; margin:0 0 24px; font-size:13px; }
   a.btn, button { display:inline-block; padding:10px 18px; border-radius:8px; background:#111;
-          color:#fff; text-decoration:none; border:0; cursor:pointer; font-size:14px; }
+           color:#fff; text-decoration:none; border:0; cursor:pointer; font-size:14px; }
+  .actions { display:flex; flex-wrap:wrap; gap:10px; align-items:center; }
+  .preview { display:block; width:100%; max-height:60vh; margin:0 0 16px; border-radius:10px; background:#000; }
+  audio.preview { background:transparent; }
   input[type=password] { width:100%; padding:10px 12px; border:1px solid #ddd; border-radius:8px;
-          font-size:14px; box-sizing:border-box; margin-bottom:12px; }
+           font-size:14px; box-sizing:border-box; margin-bottom:12px; }
   form { margin-top:8px; } .meta { color:#666; font-size:13px; margin-top:18px; }
 </style></head><body>
 <div class="card"><h1>$n</h1><p class="size">$s</p>$cta

--- a/api-kt/src/main/kotlin/site/daydream/mote/model/Drive.kt
+++ b/api-kt/src/main/kotlin/site/daydream/mote/model/Drive.kt
@@ -98,6 +98,7 @@ data class DriveShare(
     val nodeId: Long = 0,
     val tokenHash: String = "",
     val tokenPrefix: String = "",
+    val storedToken: String? = null,
     val passwordHash: String? = null,
     val expiresAt: Long? = null,
     val createdAt: Long = 0,
@@ -228,4 +229,6 @@ data class DriveSharedItemDto(
     val name: String,
     val size: Long,
     val path: String,
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val url: String? = null,
 )

--- a/api-kt/src/main/kotlin/site/daydream/mote/service/DriveService.kt
+++ b/api-kt/src/main/kotlin/site/daydream/mote/service/DriveService.kt
@@ -269,29 +269,6 @@ class DriveService(
         val n = findById(id)
         if (n.deletedAt == null) return
         if (n.deleteBatchId == null) {
-            // Keep as raw SQL for consistency with bulk restore below.
-            dsl.execute(
-                "UPDATE drive_nodes SET deleted_at = NULL, delete_batch_id = NULL WHERE id = ?",
-                id,
-            )
-            return
-        }
-
-        val roots = dsl.resultQuery(
-            """
-            SELECT * FROM drive_nodes n
-            WHERE n.delete_batch_id = ?
-              AND (
-                n.parent_id IS NULL
-                OR NOT EXISTS (
-                  SELECT 1 FROM drive_nodes p
-                  WHERE p.id = n.parent_id AND p.delete_batch_id = n.delete_batch_id
-                )
-              )
-            """.trimIndent(),
-            n.deleteBatchId,
-        ).fetch { rec -> mapNodeFromRecord(rec) }
-        for (r in roots) {
             val hit = dsl.fetchOne(
                 """
                 SELECT EXISTS(
@@ -301,13 +278,52 @@ class DriveService(
                     AND deleted_at IS NULL
                 )
                 """.trimIndent(),
-                r.parentId, r.name,
+                n.parentId, n.name,
             )?.get(0, Int::class.java) ?: 0
             if (hit == 1) throw ConflictException("name already exists in this folder")
+            dsl.execute(
+                "UPDATE drive_nodes SET deleted_at = NULL, delete_batch_id = NULL WHERE id = ?",
+                id,
+            )
+            return
         }
+
+        val conflicts = dsl.fetchOne(
+            """
+            WITH RECURSIVE subtree(id) AS (
+              SELECT id FROM drive_nodes WHERE id = ? AND deleted_at IS NOT NULL
+              UNION ALL
+              SELECT n.id FROM drive_nodes n JOIN subtree s ON n.parent_id = s.id
+              WHERE n.deleted_at IS NOT NULL AND n.delete_batch_id = ?
+            )
+            SELECT COUNT(*)
+            FROM drive_nodes r
+            WHERE r.id IN (SELECT id FROM subtree)
+              AND EXISTS (
+                SELECT 1 FROM drive_nodes a
+                WHERE COALESCE(a.parent_id, 0) = COALESCE(r.parent_id, 0)
+                  AND LOWER(a.name) = LOWER(r.name)
+                  AND a.deleted_at IS NULL
+                  AND a.id NOT IN (SELECT id FROM subtree)
+              )
+            """.trimIndent(),
+            id, n.deleteBatchId,
+        )?.get(0, Int::class.java) ?: 0
+        if (conflicts > 0) throw ConflictException("name already exists in this folder")
+
         dsl.execute(
-            "UPDATE drive_nodes SET deleted_at = NULL, delete_batch_id = NULL WHERE delete_batch_id = ?",
-            n.deleteBatchId,
+            """
+            WITH RECURSIVE subtree(id) AS (
+              SELECT id FROM drive_nodes WHERE id = ? AND deleted_at IS NOT NULL
+              UNION ALL
+              SELECT n.id FROM drive_nodes n JOIN subtree s ON n.parent_id = s.id
+              WHERE n.deleted_at IS NOT NULL AND n.delete_batch_id = ?
+            )
+            UPDATE drive_nodes
+            SET deleted_at = NULL, delete_batch_id = NULL
+            WHERE id IN (SELECT id FROM subtree)
+            """.trimIndent(),
+            id, n.deleteBatchId,
         )
     }
 

--- a/api-kt/src/main/kotlin/site/daydream/mote/service/DriveShareService.kt
+++ b/api-kt/src/main/kotlin/site/daydream/mote/service/DriveShareService.kt
@@ -35,15 +35,21 @@ class DriveShareService(
         val exp = if (expiresAt != null && expiresAt > 0) expiresAt else null
         val now = System.currentTimeMillis()
 
-        val id = dsl.insertInto(DRIVE_SHARES)
-            .set(DRIVE_SHARES.NODE_ID, nodeId)
-            .set(DRIVE_SHARES.TOKEN_HASH, hash)
-            .set(DRIVE_SHARES.TOKEN_PREFIX, prefix)
-            .set(DRIVE_SHARES.PASSWORD_HASH, pwHash)
-            .set(DRIVE_SHARES.EXPIRES_AT, exp)
-            .set(DRIVE_SHARES.CREATED_AT, now)
-            .returningResult(DRIVE_SHARES.ID)
-            .fetchOne()!!.value1()
+        val id = dsl.resultQuery(
+            """
+            INSERT INTO drive_shares
+              (node_id, token_hash, token_prefix, token, password_hash, expires_at, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            RETURNING id
+            """.trimIndent(),
+            nodeId,
+            hash,
+            prefix,
+            token,
+            pwHash,
+            exp,
+            now,
+        ).fetchOne()!!.get("id", Long::class.java)
         return findById(id) to token
     }
 
@@ -162,6 +168,7 @@ class DriveShareService(
         nodeId = rec.get("node_id", Long::class.java),
         tokenHash = rec.get("token_hash", String::class.java),
         tokenPrefix = rec.get("token_prefix", String::class.java),
+        storedToken = rec.get("token", String::class.java),
         passwordHash = rec.get("password_hash", String::class.java),
         expiresAt = rec.get("expires_at", Long::class.javaObjectType),
         createdAt = rec.get("created_at", Long::class.java),

--- a/api-kt/src/main/resources/db/migration/V3__drive_share_token.sql
+++ b/api-kt/src/main/resources/db/migration/V3__drive_share_token.sql
@@ -1,0 +1,1 @@
+ALTER TABLE drive_shares ADD COLUMN token TEXT;

--- a/api-py/app/handler/drive.py
+++ b/api-py/app/handler/drive.py
@@ -413,7 +413,12 @@ def list_shares(payload: DriveIdQuery):
 @drive_bp.get('/shares/all')
 @validate(type='query')
 def list_all_shares(payload: DriveSharesAllQuery):
-    return _share().list_all(payload.include_expired)
+    rows = _share().list_all(payload.include_expired)
+    for row in rows:
+        token = row.pop('token', None)
+        if token:
+            row['url'] = _share_url(token)
+    return rows
 
 
 @drive_bp.post('/share/revoke')

--- a/api-py/app/handler/shared_drive.py
+++ b/api-py/app/handler/shared_drive.py
@@ -5,6 +5,8 @@ Mirrors api-go/internal/handlers/drive_share.go.
 from __future__ import annotations
 
 import os
+import hashlib
+import hmac
 from urllib.parse import quote
 
 from flask import (
@@ -49,9 +51,12 @@ _LANDING_HTML = r"""<!doctype html>
   h1 { font-size:18px; margin:0 0 4px; word-break:break-all; }
   p.size { color:#888; margin:0 0 24px; font-size:13px; }
   a.btn, button { display:inline-block; padding:10px 18px; border-radius:8px; background:#111;
-          color:#fff; text-decoration:none; border:0; cursor:pointer; font-size:14px; }
+           color:#fff; text-decoration:none; border:0; cursor:pointer; font-size:14px; }
+  .actions { display:flex; flex-wrap:wrap; gap:10px; align-items:center; }
+  .preview { display:block; width:100%; max-height:60vh; margin:0 0 16px; border-radius:10px; background:#000; }
+  audio.preview { background:transparent; }
   input[type=password] { width:100%; padding:10px 12px; border:1px solid #ddd; border-radius:8px;
-          font-size:14px; box-sizing:border-box; margin-bottom:12px; }
+           font-size:14px; box-sizing:border-box; margin-bottom:12px; }
   form { margin-top:8px; }
   .meta { color:#666; font-size:13px; margin-top:18px; }
 </style>
@@ -66,7 +71,14 @@ _LANDING_HTML = r"""<!doctype html>
         <button type="submit">Unlock</button>
       </form>
     {% else %}
-      <a class="btn" href="/shared-files/{{ token }}/download">Download</a>
+      {% if mime_type.startswith('video/') %}
+        <video class="preview" src="/shared-files/{{ token }}/preview" controls preload="metadata"></video>
+      {% elif mime_type.startswith('audio/') %}
+        <audio class="preview" src="/shared-files/{{ token }}/preview" controls preload="metadata"></audio>
+      {% endif %}
+      <div class="actions">
+        <a class="btn" href="/shared-files/{{ token }}/download">Download</a>
+      </div>
     {% endif %}
     <p class="meta">Shared via Mote Drive</p>
   </div>
@@ -107,7 +119,19 @@ def _password_ok(share, token: str) -> bool:
     if share.password_hash is None:
         return True
     cookie = request.cookies.get(share_password_cookie_name(token))
-    return cookie == '1'
+    return bool(cookie) and hmac.compare_digest(
+        cookie, _share_password_cookie_value(share, token)
+    )
+
+
+def _share_password_cookie_value(share, token: str) -> str:
+    if share.password_hash is None:
+        abort(400, description='share has no password')
+    return hmac.new(
+        share.password_hash.encode(),
+        token.encode(),
+        hashlib.sha256,
+    ).hexdigest()
 
 
 def _client_ip() -> str:
@@ -157,6 +181,7 @@ def landing(token: str):
         _LANDING_HTML,
         name=node.name,
         size=_human_size(node.size or 0),
+        mime_type=node.mime_type(),
         has_password=has_password,
         authed=authed,
         token=token,
@@ -174,7 +199,7 @@ def auth(token: str):
     resp = make_response(redirect(f'/shared-files/{token}', code=303))
     resp.set_cookie(
         share_password_cookie_name(token),
-        '1',
+        _share_password_cookie_value(share, token),
         path=f'/shared-files/{token}',
         max_age=60 * 60 * 24,
         httponly=True,

--- a/api-py/app/model.py
+++ b/api-py/app/model.py
@@ -538,6 +538,7 @@ class DriveShare(db.Model):
     )
     token_hash = db.Column(db.Text, nullable=False, unique=True)
     token_prefix = db.Column(db.Text, nullable=False)
+    token = db.Column(db.Text, nullable=True)
     password_hash = db.Column(db.Text, nullable=True)
     expires_at = db.Column(db.BigInteger, nullable=True)
     created_at = db.Column(db.BigInteger, nullable=False)

--- a/api-py/app/services/drive.py
+++ b/api-py/app/services/drive.py
@@ -446,6 +446,19 @@ class DriveService:
         if n.deleted_at is None:
             return
         if not n.delete_batch_id:
+            hit = db.session.execute(
+                text(
+                    'SELECT EXISTS('
+                    '  SELECT 1 FROM drive_nodes '
+                    '  WHERE COALESCE(parent_id, 0) = COALESCE(:pid, 0) '
+                    '    AND LOWER(name) = LOWER(:name) '
+                    '    AND deleted_at IS NULL'
+                    ')'
+                ),
+                {'pid': n.parent_id, 'name': n.name},
+            ).scalar()
+            if hit:
+                raise DriveNameConflict('name already exists in this folder')
             db.session.execute(
                 text(
                     'UPDATE drive_nodes SET deleted_at = NULL, delete_batch_id = NULL '
@@ -457,41 +470,41 @@ class DriveService:
             return
 
         try:
-            roots = db.session.execute(
+            conflicts = db.session.execute(
                 text(
-                    'SELECT * FROM drive_nodes n '
-                    'WHERE n.delete_batch_id = :batch '
-                    '  AND ('
-                    '    n.parent_id IS NULL '
-                    '    OR NOT EXISTS ('
-                    '      SELECT 1 FROM drive_nodes p '
-                    '      WHERE p.id = n.parent_id '
-                    '        AND p.delete_batch_id = n.delete_batch_id'
-                    '    )'
+                    'WITH RECURSIVE subtree(id) AS ('
+                    '  SELECT id FROM drive_nodes WHERE id = :id AND deleted_at IS NOT NULL '
+                    '  UNION ALL '
+                    '  SELECT n.id FROM drive_nodes n JOIN subtree s ON n.parent_id = s.id '
+                    '  WHERE n.deleted_at IS NOT NULL AND n.delete_batch_id = :batch'
+                    ') '
+                    'SELECT COUNT(*) FROM drive_nodes r '
+                    'WHERE r.id IN (SELECT id FROM subtree) '
+                    '  AND EXISTS ('
+                    '    SELECT 1 FROM drive_nodes a '
+                    '    WHERE COALESCE(a.parent_id, 0) = COALESCE(r.parent_id, 0) '
+                    '      AND LOWER(a.name) = LOWER(r.name) '
+                    '      AND a.deleted_at IS NULL '
+                    '      AND a.id NOT IN (SELECT id FROM subtree)'
                     '  )'
                 ),
-                {'batch': n.delete_batch_id},
-            ).all()
-            for r in roots:
-                hit = db.session.execute(
-                    text(
-                        'SELECT EXISTS('
-                        '  SELECT 1 FROM drive_nodes '
-                        '  WHERE COALESCE(parent_id, 0) = COALESCE(:pid, 0) '
-                        '    AND LOWER(name) = LOWER(:name) '
-                        '    AND deleted_at IS NULL'
-                        ')'
-                    ),
-                    {'pid': r.parent_id, 'name': r.name},
-                ).scalar()
-                if hit:
-                    raise DriveNameConflict('name already exists in this folder')
+                {'id': node_id, 'batch': n.delete_batch_id},
+            ).scalar()
+            if conflicts:
+                raise DriveNameConflict('name already exists in this folder')
+
             db.session.execute(
                 text(
+                    'WITH RECURSIVE subtree(id) AS ('
+                    '  SELECT id FROM drive_nodes WHERE id = :id AND deleted_at IS NOT NULL '
+                    '  UNION ALL '
+                    '  SELECT n.id FROM drive_nodes n JOIN subtree s ON n.parent_id = s.id '
+                    '  WHERE n.deleted_at IS NOT NULL AND n.delete_batch_id = :batch'
+                    ') '
                     'UPDATE drive_nodes SET deleted_at = NULL, delete_batch_id = NULL '
-                    'WHERE delete_batch_id = :batch'
+                    'WHERE id IN (SELECT id FROM subtree)'
                 ),
-                {'batch': n.delete_batch_id},
+                {'id': node_id, 'batch': n.delete_batch_id},
             )
             db.session.commit()
         except Exception:

--- a/api-py/app/services/drive_share.py
+++ b/api-py/app/services/drive_share.py
@@ -54,6 +54,7 @@ class ShareRow:
     node_id: int
     token_hash: str
     token_prefix: str
+    stored_token: Optional[str]
     password_hash: Optional[str]
     expires_at: Optional[int]
     created_at: int
@@ -65,6 +66,7 @@ class ShareRow:
             node_id=r.node_id,
             token_hash=r.token_hash,
             token_prefix=r.token_prefix,
+            stored_token=getattr(r, 'token', None),
             password_hash=r.password_hash,
             expires_at=r.expires_at,
             created_at=r.created_at,
@@ -130,13 +132,14 @@ class DriveShareService:
             new_id = db.session.execute(
                 text(
                     'INSERT INTO drive_shares '
-                    '(node_id, token_hash, token_prefix, password_hash, expires_at, created_at) '
-                    'VALUES (:nid, :h, :p, :pw, :exp, :now) RETURNING id'
+                    '(node_id, token_hash, token_prefix, token, password_hash, expires_at, created_at) '
+                    'VALUES (:nid, :h, :p, :token, :pw, :exp, :now) RETURNING id'
                 ),
                 {
                     'nid': node_id,
                     'h': token_hash,
                     'p': prefix,
+                    'token': token,
                     'pw': pw_hash,
                     'exp': expires_at if expires_at else None,
                     'now': now,
@@ -151,6 +154,7 @@ class DriveShareService:
             node_id=node_id,
             token_hash=token_hash,
             token_prefix=prefix,
+            stored_token=token,
             password_hash=pw_hash,
             expires_at=expires_at if expires_at else None,
             created_at=now,
@@ -211,6 +215,7 @@ class DriveShareService:
                     'name': r.node_name,
                     'size': r.node_size,
                     'path': path,
+                    'token': r.token,
                 }
             )
         return out

--- a/api-py/migrations/versions/ac0d1b2c3e4f_add_drive_share_token.py
+++ b/api-py/migrations/versions/ac0d1b2c3e4f_add_drive_share_token.py
@@ -1,0 +1,24 @@
+"""add drive share token
+
+Revision ID: ac0d1b2c3e4f
+Revises: 98a1ebb8af73
+Create Date: 2026-05-01 10:06:55.385000
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = 'ac0d1b2c3e4f'
+down_revision = '98a1ebb8af73'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('drive_shares', sa.Column('token', sa.Text(), nullable=True))
+
+
+def downgrade():
+    op.drop_column('drive_shares', 'token')

--- a/api-rs/Cargo.lock
+++ b/api-rs/Cargo.lock
@@ -1816,6 +1816,7 @@ dependencies = [
  "futures",
  "futures-util",
  "hex",
+ "hmac",
  "image",
  "include_dir",
  "jieba-rs",

--- a/api-rs/Cargo.toml
+++ b/api-rs/Cargo.toml
@@ -58,6 +58,7 @@ jieba-rs = "0.7"
 # Drive feature
 bcrypt = "0.15"
 sha2 = "0.10"
+hmac = "0.12"
 hex = "0.4"
 subtle = "2"
 async_zip = { version = "0.0.17", features = ["tokio", "deflate"] }

--- a/api-rs/migrations/20260501020655_drive_share_token.sql
+++ b/api-rs/migrations/20260501020655_drive_share_token.sql
@@ -1,0 +1,1 @@
+ALTER TABLE drive_shares ADD COLUMN token TEXT;

--- a/api-rs/src/model/drive.rs
+++ b/api-rs/src/model/drive.rs
@@ -120,9 +120,7 @@ pub fn mime_for_ext(ext: &str) -> String {
         "mkv" => "video/x-matroska".into(),
         "avi" => "video/x-msvideo".into(),
         "doc" => "application/msword".into(),
-        "docx" => {
-            "application/vnd.openxmlformats-officedocument.wordprocessingml.document".into()
-        }
+        "docx" => "application/vnd.openxmlformats-officedocument.wordprocessingml.document".into(),
         "xls" => "application/vnd.ms-excel".into(),
         "xlsx" => "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet".into(),
         "ppt" => "application/vnd.ms-powerpoint".into(),
@@ -140,6 +138,7 @@ pub struct DriveShareRow {
     pub node_id: i64,
     pub token_hash: String,
     pub token_prefix: String,
+    pub token: Option<String>,
     pub password_hash: Option<String>,
     pub expires_at: Option<i64>,
     pub created_at: i64,
@@ -307,4 +306,8 @@ pub struct DriveSharedItemDTO {
     pub name: String,
     pub size: i64,
     pub path: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub url: Option<String>,
+    #[serde(skip)]
+    pub token: Option<String>,
 }

--- a/api-rs/src/route/drive_api.rs
+++ b/api-rs/src/route/drive_api.rs
@@ -76,10 +76,7 @@ async fn create_folder(
     State(state): State<AppState>,
     Json(req): Json<DriveCreateFolderRequest>,
 ) -> ApiResult<Json<DriveNode>> {
-    let n = state
-        .drive
-        .create_folder(req.parent_id, &req.name)
-        .await?;
+    let n = state.drive.create_folder(req.parent_id, &req.name).await?;
     Ok(Json(n))
 }
 
@@ -157,12 +154,15 @@ async fn thumb(
         .filter(|h| !h.is_empty())
         .map(|h| format!("\"{}\"", h));
 
-    if let (Some(et), Some(inm)) = (&etag, headers.get(IF_NONE_MATCH).and_then(|v| v.to_str().ok()))
-    {
+    if let (Some(et), Some(inm)) = (
+        &etag,
+        headers.get(IF_NONE_MATCH).and_then(|v| v.to_str().ok()),
+    ) {
         if inm.split(',').any(|s| s.trim() == et) {
             let mut resp = Response::new(Body::empty());
             *resp.status_mut() = StatusCode::NOT_MODIFIED;
-            resp.headers_mut().insert(ETAG, HeaderValue::from_str(et).unwrap());
+            resp.headers_mut()
+                .insert(ETAG, HeaderValue::from_str(et).unwrap());
             resp.headers_mut().insert(
                 CACHE_CONTROL,
                 HeaderValue::from_static("private, max-age=0, must-revalidate"),
@@ -175,7 +175,10 @@ async fn thumb(
     let f = tokio::fs::File::open(&path)
         .await
         .map_err(|_| ApiError::NotFound("not found".into()))?;
-    let st = f.metadata().await.map_err(|e| ApiError::ServerError(e.to_string()))?;
+    let st = f
+        .metadata()
+        .await
+        .map_err(|e| ApiError::ServerError(e.to_string()))?;
     let stream = ReaderStream::new(f);
     let body = Body::from_stream(stream);
     let mut resp = Response::new(body);
@@ -245,7 +248,13 @@ pub(crate) async fn serve_blob(
     }
     let blob = node.blob_path.clone().unwrap();
     let abs = state.drive.blob_abs_path(&blob);
-    serve_file(&abs, &node.name, node.mime_type.as_deref(), force_attachment).await
+    serve_file(
+        &abs,
+        &node.name,
+        node.mime_type.as_deref(),
+        force_attachment,
+    )
+    .await
 }
 
 pub(crate) async fn serve_file(
@@ -431,9 +440,15 @@ async fn list_shares(
 
 async fn list_all_shares(
     State(state): State<AppState>,
+    headers: HeaderMap,
     Query(q): Query<DriveSharesAllQuery>,
 ) -> ApiResult<Json<Vec<DriveSharedItemDTO>>> {
-    let out = state.drive_share.list_all(q.include_expired).await?;
+    let mut out = state.drive_share.list_all(q.include_expired).await?;
+    for item in &mut out {
+        if let Some(token) = item.token.as_deref() {
+            item.url = Some(share_url(&headers, token));
+        }
+    }
     Ok(Json(out))
 }
 

--- a/api-rs/src/route/drive_share_page.rs
+++ b/api-rs/src/route/drive_share_page.rs
@@ -8,8 +8,11 @@ use axum::http::{HeaderValue, StatusCode};
 use axum::response::{Html, IntoResponse, Response};
 use axum::routing::{get, post};
 use axum::{Json as AxumJson, Router};
+use hmac::{Hmac, Mac};
 use serde::Deserialize;
 use serde_json::json;
+use sha2::Sha256;
+use subtle::ConstantTimeEq;
 
 const SHARE_PW_COOKIE_PREFIX: &str = "drive_share_pw_";
 
@@ -24,25 +27,31 @@ pub fn create_routes() -> Router<AppState> {
 fn cookie_name(token: &str) -> String {
     let n = std::cmp::min(8, token.len());
     let prefix = &token[..n];
-    format!(
-        "{}{}",
-        SHARE_PW_COOKIE_PREFIX,
-        prefix.replace('-', "_")
-    )
+    format!("{}{}", SHARE_PW_COOKIE_PREFIX, prefix.replace('-', "_"))
 }
 
-fn password_ok(headers: &HeaderMap, token: &str, has_password: bool) -> bool {
-    if !has_password {
+type HmacSha256 = Hmac<Sha256>;
+
+fn cookie_value(token: &str, password_hash: &str) -> String {
+    let mut mac =
+        HmacSha256::new_from_slice(password_hash.as_bytes()).expect("HMAC accepts any key length");
+    mac.update(token.as_bytes());
+    hex::encode(mac.finalize().into_bytes())
+}
+
+fn password_ok(headers: &HeaderMap, token: &str, password_hash: Option<&str>) -> bool {
+    let Some(password_hash) = password_hash else {
         return true;
-    }
-    let want = cookie_name(token);
+    };
+    let name = cookie_name(token);
+    let want = cookie_value(token, password_hash);
     let Some(c) = headers.get("cookie").and_then(|v| v.to_str().ok()) else {
         return false;
     };
     for kv in c.split(';') {
         let kv = kv.trim();
         if let Some((k, v)) = kv.split_once('=') {
-            if k == want && v == "1" {
+            if k == name && bool::from(v.as_bytes().ct_eq(want.as_bytes())) {
                 return true;
             }
         }
@@ -83,7 +92,7 @@ async fn landing(
 ) -> ApiResult<Response> {
     let (share, node) = state.drive_share.resolve(&token).await?;
     let has_password = share.password_hash.is_some();
-    let authed = password_ok(&headers, &token, has_password);
+    let authed = password_ok(&headers, &token, share.password_hash.as_deref());
     let wants_json = headers
         .get(ACCEPT)
         .and_then(|v| v.to_str().ok())
@@ -102,7 +111,18 @@ async fn landing(
         return Ok(AxumJson(body).into_response());
     }
 
-    let html = render_landing(&node.name, &human_size(node.size.unwrap_or(0)), has_password, authed, &token);
+    let mime_type = node
+        .mime_type
+        .as_deref()
+        .unwrap_or("application/octet-stream");
+    let html = render_landing(
+        &node.name,
+        &human_size(node.size.unwrap_or(0)),
+        mime_type,
+        has_password,
+        authed,
+        &token,
+    );
     Ok(Html(html).into_response())
 }
 
@@ -124,9 +144,15 @@ async fn auth(
     }
     let (share, _) = state.drive_share.resolve(&token).await?;
     state.drive_share.verify_password(&share, &form.password)?;
+    let cookie_value = share
+        .password_hash
+        .as_deref()
+        .map(|h| cookie_value(&token, h))
+        .ok_or_else(|| ApiError::BadRequest("share has no password".into()))?;
     let cookie = format!(
-        "{}=1; Path=/shared-files/{}; HttpOnly; SameSite=Lax; Max-Age=86400",
+        "{}={}; Path=/shared-files/{}; HttpOnly; SameSite=Lax; Max-Age=86400",
         cookie_name(&token),
+        cookie_value,
         token
     );
     let mut resp = Response::new(axum::body::Body::empty());
@@ -166,7 +192,7 @@ async fn serve_shared(
 ) -> ApiResult<Response> {
     let (share, node) = state.drive_share.resolve(&token).await?;
     let has_password = share.password_hash.is_some();
-    if has_password && !password_ok(&headers, &token, true) {
+    if has_password && !password_ok(&headers, &token, share.password_hash.as_deref()) {
         let mut resp = Response::new(axum::body::Body::empty());
         *resp.status_mut() = StatusCode::SEE_OTHER;
         resp.headers_mut().insert(
@@ -200,7 +226,14 @@ async fn rate_limit_ok(state: &AppState, key: &str, expires: u64, max_count: i64
     }
 }
 
-fn render_landing(name: &str, size: &str, has_password: bool, authed: bool, token: &str) -> String {
+fn render_landing(
+    name: &str,
+    size: &str,
+    mime_type: &str,
+    has_password: bool,
+    authed: bool,
+    token: &str,
+) -> String {
     let body = if has_password && !authed {
         format!(
             r#"<form method="post" action="/shared-files/{token}/auth">
@@ -210,9 +243,20 @@ fn render_landing(name: &str, size: &str, has_password: bool, authed: bool, toke
             token = html_escape(token)
         )
     } else {
+        let token = html_escape(token);
+        let preview = if mime_type.starts_with("video/") {
+            format!(
+                r#"<video class="preview" src="/shared-files/{token}/preview" controls preload="metadata"></video>"#
+            )
+        } else if mime_type.starts_with("audio/") {
+            format!(
+                r#"<audio class="preview" src="/shared-files/{token}/preview" controls preload="metadata"></audio>"#
+            )
+        } else {
+            String::new()
+        };
         format!(
-            r#"<a class="btn" href="/shared-files/{token}/download">Download</a>"#,
-            token = html_escape(token)
+            r#"{preview}<div class="actions"><a class="btn" href="/shared-files/{token}/download">Download</a></div>"#
         )
     };
     format!(
@@ -232,6 +276,9 @@ fn render_landing(name: &str, size: &str, has_password: bool, authed: bool, toke
   p.size {{ color:#888; margin:0 0 24px; font-size:13px; }}
   a.btn, button {{ display:inline-block; padding:10px 18px; border-radius:8px; background:#111;
           color:#fff; text-decoration:none; border:0; cursor:pointer; font-size:14px; }}
+  .actions {{ display:flex; flex-wrap:wrap; gap:10px; align-items:center; }}
+  .preview {{ display:block; width:100%; max-height:60vh; margin:0 0 16px; border-radius:10px; background:#000; }}
+  audio.preview {{ background:transparent; }}
   input[type=password] {{ width:100%; padding:10px 12px; border:1px solid #ddd; border-radius:8px;
           font-size:14px; box-sizing:border-box; margin-bottom:12px; }}
   form {{ margin-top:8px; }}

--- a/api-rs/src/service/drive_service.rs
+++ b/api-rs/src/service/drive_service.rs
@@ -294,22 +294,17 @@ SELECT id, name FROM chain ORDER BY depth DESC"#,
         Ok(())
     }
 
-    pub async fn move_nodes(
-        &self,
-        ids: &[i64],
-        new_parent_id: Option<i64>,
-    ) -> DriveResult<()> {
+    pub async fn move_nodes(&self, ids: &[i64], new_parent_id: Option<i64>) -> DriveResult<()> {
         if ids.is_empty() {
             return Ok(());
         }
         let mut tx = self.pool.begin().await?;
         if let Some(pid) = new_parent_id {
-            let row: Option<(String, Option<i64>)> = sqlx::query_as(
-                "SELECT type, deleted_at FROM drive_nodes WHERE id = ?",
-            )
-            .bind(pid)
-            .fetch_optional(&mut *tx)
-            .await?;
+            let row: Option<(String, Option<i64>)> =
+                sqlx::query_as("SELECT type, deleted_at FROM drive_nodes WHERE id = ?")
+                    .bind(pid)
+                    .fetch_optional(&mut *tx)
+                    .await?;
             let (typ, del) = row.ok_or(DriveError::InvalidParent)?;
             if del.is_some() {
                 return Err(DriveError::InvalidParent);
@@ -392,31 +387,6 @@ WHERE id IN (SELECT id FROM subtree)"#,
             return Ok(());
         }
         let Some(batch) = n.delete_batch_id.clone() else {
-            sqlx::query(
-                "UPDATE drive_nodes SET deleted_at = NULL, delete_batch_id = NULL WHERE id = ?",
-            )
-            .bind(id)
-            .execute(&self.pool)
-            .await?;
-            return Ok(());
-        };
-        let mut tx = self.pool.begin().await?;
-        let roots = sqlx::query_as::<_, DriveNodeRow>(
-            r#"
-SELECT * FROM drive_nodes n
-WHERE n.delete_batch_id = ?
-  AND (
-    n.parent_id IS NULL
-    OR NOT EXISTS (
-      SELECT 1 FROM drive_nodes p
-      WHERE p.id = n.parent_id AND p.delete_batch_id = n.delete_batch_id
-    )
-  )"#,
-        )
-        .bind(&batch)
-        .fetch_all(&mut *tx)
-        .await?;
-        for r in roots {
             let hit: i64 = sqlx::query_scalar(
                 r#"
 SELECT EXISTS(
@@ -426,17 +396,61 @@ SELECT EXISTS(
     AND deleted_at IS NULL
 )"#,
             )
-            .bind(r.parent_id)
-            .bind(&r.name)
-            .fetch_one(&mut *tx)
+            .bind(n.parent_id)
+            .bind(&n.name)
+            .fetch_one(&self.pool)
             .await?;
             if hit == 1 {
                 return Err(DriveError::NameConflict);
             }
+            sqlx::query(
+                "UPDATE drive_nodes SET deleted_at = NULL, delete_batch_id = NULL WHERE id = ?",
+            )
+            .bind(id)
+            .execute(&self.pool)
+            .await?;
+            return Ok(());
+        };
+        let mut tx = self.pool.begin().await?;
+        let conflicts: i64 = sqlx::query_scalar(
+            r#"
+WITH RECURSIVE subtree(id) AS (
+  SELECT id FROM drive_nodes WHERE id = ? AND deleted_at IS NOT NULL
+  UNION ALL
+  SELECT n.id FROM drive_nodes n JOIN subtree s ON n.parent_id = s.id
+  WHERE n.deleted_at IS NOT NULL AND n.delete_batch_id = ?
+)
+SELECT COUNT(*)
+FROM drive_nodes r
+WHERE r.id IN (SELECT id FROM subtree)
+  AND EXISTS (
+    SELECT 1 FROM drive_nodes a
+    WHERE COALESCE(a.parent_id, 0) = COALESCE(r.parent_id, 0)
+      AND LOWER(a.name) = LOWER(r.name)
+      AND a.deleted_at IS NULL
+      AND a.id NOT IN (SELECT id FROM subtree)
+  )"#,
+        )
+        .bind(id)
+        .bind(&batch)
+        .fetch_one(&mut *tx)
+        .await?;
+        if conflicts > 0 {
+            return Err(DriveError::NameConflict);
         }
         sqlx::query(
-            "UPDATE drive_nodes SET deleted_at = NULL, delete_batch_id = NULL WHERE delete_batch_id = ?",
+            r#"
+WITH RECURSIVE subtree(id) AS (
+  SELECT id FROM drive_nodes WHERE id = ? AND deleted_at IS NOT NULL
+  UNION ALL
+  SELECT n.id FROM drive_nodes n JOIN subtree s ON n.parent_id = s.id
+  WHERE n.deleted_at IS NOT NULL AND n.delete_batch_id = ?
+)
+UPDATE drive_nodes
+SET deleted_at = NULL, delete_batch_id = NULL
+WHERE id IN (SELECT id FROM subtree)"#,
         )
+        .bind(id)
         .bind(&batch)
         .execute(&mut *tx)
         .await?;
@@ -646,11 +660,7 @@ SELECT id, type, name, blob_path, rel_path FROM subtree"#,
         Ok(row.map(DriveNode::from_row))
     }
 
-    pub async fn auto_rename(
-        &self,
-        parent_id: Option<i64>,
-        name: &str,
-    ) -> DriveResult<String> {
+    pub async fn auto_rename(&self, parent_id: Option<i64>, name: &str) -> DriveResult<String> {
         if self.find_active_sibling(parent_id, name).await?.is_none() {
             return Ok(name.to_string());
         }

--- a/api-rs/src/service/drive_share_service.rs
+++ b/api-rs/src/service/drive_share_service.rs
@@ -49,12 +49,13 @@ impl DriveShareService {
         let exp = expires_at.filter(|v| *v > 0);
         let now = Utc::now().timestamp_millis();
         let id: i64 = sqlx::query_scalar(
-            "INSERT INTO drive_shares (node_id, token_hash, token_prefix, password_hash, expires_at, created_at)
-             VALUES (?, ?, ?, ?, ?, ?) RETURNING id",
+            "INSERT INTO drive_shares (node_id, token_hash, token_prefix, token, password_hash, expires_at, created_at)
+             VALUES (?, ?, ?, ?, ?, ?, ?) RETURNING id",
         )
         .bind(node_id)
         .bind(&hash)
         .bind(prefix)
+        .bind(&token)
         .bind(&pw_hash)
         .bind(exp)
         .bind(now)
@@ -65,7 +66,11 @@ impl DriveShareService {
             .fetch_one(&self.pool)
             .await?;
         let has_password = row.password_hash.is_some();
-        Ok(CreatedShare { row, token, has_password })
+        Ok(CreatedShare {
+            row,
+            token,
+            has_password,
+        })
     }
 
     pub async fn list_by_node(&self, node_id: i64) -> DriveResult<Vec<DriveShareRow>> {
@@ -95,12 +100,11 @@ impl DriveShareService {
         }
         let hash = sha256_hex(token);
         let prefix = &hash[..8];
-        let candidates = sqlx::query_as::<_, DriveShareRow>(
-            "SELECT * FROM drive_shares WHERE token_prefix = ?",
-        )
-        .bind(prefix)
-        .fetch_all(&self.pool)
-        .await?;
+        let candidates =
+            sqlx::query_as::<_, DriveShareRow>("SELECT * FROM drive_shares WHERE token_prefix = ?")
+                .bind(prefix)
+                .fetch_all(&self.pool)
+                .await?;
         let h_bytes = hash.as_bytes();
         let m = candidates
             .into_iter()
@@ -128,13 +132,10 @@ impl DriveShareService {
         }
     }
 
-    pub async fn list_all(
-        &self,
-        include_expired: bool,
-    ) -> DriveResult<Vec<DriveSharedItemDTO>> {
+    pub async fn list_all(&self, include_expired: bool) -> DriveResult<Vec<DriveSharedItemDTO>> {
         let now = Utc::now().timestamp_millis();
         let sql_base = r#"
-SELECT s.id, s.node_id, s.password_hash, s.expires_at, s.created_at,
+SELECT s.id, s.node_id, s.token, s.password_hash, s.expires_at, s.created_at,
        n.name AS name, COALESCE(n.size, 0) AS size, n.parent_id AS node_parent_id
 FROM drive_shares s
 JOIN drive_nodes n ON n.id = s.node_id
@@ -161,7 +162,11 @@ WHERE n.deleted_at IS NULL"#;
                     p.clone()
                 } else {
                     let bcs = self.drive.breadcrumbs(pid).await?;
-                    let p = bcs.into_iter().map(|b| b.name).collect::<Vec<_>>().join("/");
+                    let p = bcs
+                        .into_iter()
+                        .map(|b| b.name)
+                        .collect::<Vec<_>>()
+                        .join("/");
                     path_cache.insert(pid, p.clone());
                     p
                 }
@@ -178,6 +183,8 @@ WHERE n.deleted_at IS NULL"#;
                 name: r.name,
                 size: r.size,
                 path,
+                url: None,
+                token: r.token,
             });
         }
         Ok(out)
@@ -199,6 +206,7 @@ WHERE n.deleted_at IS NULL"#;
 struct ShareJoinRow {
     id: i64,
     node_id: i64,
+    token: Option<String>,
     password_hash: Option<String>,
     expires_at: Option<i64>,
     created_at: i64,

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -142,5 +142,9 @@
   "passwordProtected": "password",
   "openLink": "open link",
   "revoke": "revoke",
-  "revokeConfirm": "revoke this share link?"
+  "revokeConfirm": "revoke this share link?",
+  "emptyTrash": "empty trash",
+  "clearTrashConfirm": "permanently delete everything in trash? This cannot be undone.",
+  "viewShareLink": "view share link",
+  "shareLinkUnavailable": "This share was created before link viewing was available. Revoke it and create a new share link to view or copy it here."
 }

--- a/frontend/src/lang/zh.json
+++ b/frontend/src/lang/zh.json
@@ -142,5 +142,9 @@
   "passwordProtected": "密码",
   "openLink": "打开链接",
   "revoke": "撤销",
-  "revokeConfirm": "确定要撤销该分享链接吗？"
+  "revokeConfirm": "确定要撤销该分享链接吗？",
+  "emptyTrash": "清空回收站",
+  "clearTrashConfirm": "永久删除回收站中的所有项目？此操作无法撤销。",
+  "viewShareLink": "查看分享链接",
+  "shareLinkUnavailable": "该分享创建于支持查看链接之前，无法还原原始链接。请撤销后重新创建分享链接。"
 }

--- a/frontend/src/views/files/api.ts
+++ b/frontend/src/views/files/api.ts
@@ -179,6 +179,7 @@ export interface SharedItem {
   name: string
   size: number
   path: string
+  url?: string
 }
 
 export const listAllShares = (includeExpired = false) =>

--- a/frontend/src/views/files/shared-page.tsx
+++ b/frontend/src/views/files/shared-page.tsx
@@ -1,9 +1,12 @@
 import { useCallback, useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
 import { useNavigate } from 'react-router'
+import { CheckIcon, CopyIcon, ExternalLinkIcon } from 'lucide-react'
 
+import { Button } from '@/components/button.tsx'
 import { useConfirm } from '@/components/confirm.tsx'
-import { t, useLang } from '@/components/translation.tsx'
+import { useModal } from '@/components/modal.tsx'
+import { T, t, useLang } from '@/components/translation.tsx'
 
 import { SharedItem, listAllShares, revokeShare } from './api'
 import { TopBar } from './layout'
@@ -12,6 +15,7 @@ import { EmptyState, SharedView } from './views'
 export function SharedPage() {
   const [items, setItems] = useState<SharedItem[]>([])
   const confirm = useConfirm()
+  const modal = useModal()
   const { lang } = useLang()
   const navigate = useNavigate()
 
@@ -35,6 +39,13 @@ export function SharedPage() {
             onOpenLocation={(pid) => {
               void navigate(pid == null ? '/files' : `/files?p=${pid}`)
             }}
+            onViewLink={(item) => {
+              modal.open({
+                heading: `${t('shareLink', lang)} — ${item.name}`,
+                headingVisible: true,
+                content: <ShareLinkDialog item={item} lang={lang} />,
+              })
+            }}
             onRevoke={(id) => {
               confirm.open({
                 heading: t('revokeConfirm', lang),
@@ -54,6 +65,54 @@ export function SharedPage() {
           />
         )}
       </main>
+    </div>
+  )
+}
+
+function ShareLinkDialog({ item, lang }: { item: SharedItem; lang: 'en' | 'zh' }) {
+  const [copied, setCopied] = useState(false)
+
+  const copy = async () => {
+    if (!item.url) return
+    try {
+      await navigator.clipboard.writeText(item.url)
+      setCopied(true)
+      setTimeout(() => setCopied(false), 1500)
+    } catch (err) {
+      toast.error((err as Error).message)
+    }
+  }
+
+  if (!item.url) {
+    return (
+      <div className="text-muted-foreground max-w-md text-sm">
+        {t('shareLinkUnavailable', lang)}
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4">
+      <input
+        readOnly
+        value={item.url}
+        className="border-input bg-background focus-visible:ring-ring h-10 w-full rounded-md border px-3 text-sm focus-visible:ring-2"
+        onClick={(e) => (e.target as HTMLInputElement).select()}
+      />
+      <div className="flex justify-end gap-2">
+        <Button variant={copied ? 'secondary' : 'outline'} size="sm" onClick={() => void copy()}>
+          {copied ? <CheckIcon className="size-4 md:mr-1" /> : <CopyIcon className="size-4 md:mr-1" />}
+          <span className="hidden md:inline">
+            <T name="copy" />
+          </span>
+        </Button>
+        <Button tag="a" href={item.url} target="_blank" rel="noreferrer" size="sm">
+          <ExternalLinkIcon className="size-4 md:mr-1" />
+          <span className="hidden md:inline">
+            <T name="openLink" />
+          </span>
+        </Button>
+      </div>
     </div>
   )
 }

--- a/frontend/src/views/files/trash-page.tsx
+++ b/frontend/src/views/files/trash-page.tsx
@@ -1,6 +1,8 @@
 import { useCallback, useEffect, useState } from 'react'
 import toast from 'react-hot-toast'
+import { Trash2Icon } from 'lucide-react'
 
+import { Button } from '@/components/button.tsx'
 import { useConfirm } from '@/components/confirm.tsx'
 import { t, useLang } from '@/components/translation.tsx'
 
@@ -38,9 +40,43 @@ export function TrashPage() {
     })
   }
 
+  const handleClearTrash = () => {
+    if (items.length === 0) return
+    confirm.open({
+      heading: t('emptyTrash', lang),
+      description: t('clearTrashConfirm', lang),
+      okText: t('delete', lang),
+      cancelText: t('cancel', lang),
+      onOk: async () => {
+        try {
+          await purgeNodes(items.map((item) => item.id))
+          await refresh()
+        } catch (err) {
+          toast.error((err as Error).message)
+        }
+      },
+    })
+  }
+
   return (
     <div className="flex flex-1 flex-col">
-      <TopBar lang={lang} />
+      <TopBar
+        lang={lang}
+        extra={
+          items.length > 0 && (
+            <Button
+              variant="destructive"
+              size="sm"
+              className="gap-1.5"
+              onClick={handleClearTrash}
+              title={t('emptyTrash', lang)}
+            >
+              <Trash2Icon className="size-4" />
+              <span className="hidden sm:inline">{t('emptyTrash', lang)}</span>
+            </Button>
+          )
+        }
+      />
       <main className="flex-1 overflow-x-hidden overflow-y-auto">
         {items.length === 0 ? (
           <EmptyState trash lang={lang} />

--- a/frontend/src/views/files/use-shortcuts.tsx
+++ b/frontend/src/views/files/use-shortcuts.tsx
@@ -79,9 +79,13 @@ function isTypingTarget(t: EventTarget | null): boolean {
 }
 
 export function useShortcuts(map: BindingMap) {
-  // Capture latest map in a ref so the effect doesn't re-bind every render.
-  const latest = useRef(map)
-  latest.current = map
+  // Capture latest pre-parsed bindings in a ref so the effect doesn't re-bind
+  // and keydown handling doesn't allocate on every keystroke.
+  const latest = useRef<{ parsed: Parsed; binding: Binding }[]>([])
+  latest.current = Object.entries(map).map(([spec, binding]) => ({
+    parsed: parseSpec(spec),
+    binding,
+  }))
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {
@@ -89,14 +93,13 @@ export function useShortcuts(map: BindingMap) {
       // the keyboard.
       if (document.querySelector('[role="dialog"]')) return
       const typing = isTypingTarget(e.target)
-      for (const [spec, b] of Object.entries(latest.current)) {
-        const parsed = parseSpec(spec)
+      for (const { parsed, binding } of latest.current) {
         if (typing && parsed.key !== 'escape') continue
         if (!eventMatches(e, parsed)) continue
-        if (b.when && !b.when()) continue
+        if (binding.when && !binding.when()) continue
         e.preventDefault()
         e.stopPropagation()
-        b.run(e)
+        binding.run(e)
         return
       }
     }

--- a/frontend/src/views/files/views.tsx
+++ b/frontend/src/views/files/views.tsx
@@ -1,4 +1,4 @@
-import { ArrowDownIcon, ArrowUpIcon, FileIcon, FolderOpenIcon, KeyIcon, RotateCcwIcon, Share2Icon, Trash2Icon, UploadIcon } from 'lucide-react'
+import { ArrowDownIcon, ArrowUpIcon, FileIcon, FolderOpenIcon, KeyIcon, LinkIcon, RotateCcwIcon, Share2Icon, Trash2Icon, UploadIcon } from 'lucide-react'
 import React, { memo } from 'react'
 
 import { cx } from '@/utils/css.ts'
@@ -466,6 +466,7 @@ function formatExpiry(expires_at: number | null, lang: Lang): string {
 interface SharedViewProps {
   items: SharedItem[]
   onOpenLocation: (parentID: number | null) => void
+  onViewLink: (item: SharedItem) => void
   onRevoke: (shareID: number) => void | Promise<void>
   lang: Lang
 }
@@ -473,6 +474,7 @@ interface SharedViewProps {
 export const SharedView = memo(function SharedView({
   items,
   onOpenLocation,
+  onViewLink,
   onRevoke,
   lang,
 }: SharedViewProps) {
@@ -517,6 +519,18 @@ export const SharedView = memo(function SharedView({
                 <span>{formatExpiry(s.expires_at, lang)}</span>
               </div>
             </div>
+            <Button
+              variant="ghost"
+              size="sm"
+              onClick={() => onViewLink(s)}
+              title={t('viewShareLink', lang)}
+              aria-label={t('viewShareLink', lang)}
+            >
+              <LinkIcon className="size-4 md:mr-1" />
+              <span className="hidden md:inline">
+                <T name="openLink" />
+              </span>
+            </Button>
             <Button
               variant="ghost"
               size="sm"

--- a/frontend/src/views/sidebar/nav-links.tsx
+++ b/frontend/src/views/sidebar/nav-links.tsx
@@ -1,4 +1,4 @@
-import { CircleIcon, ExternalLinkIcon, FolderIcon, LayoutGrid as GridIcon, Share2Icon } from 'lucide-react'
+import { CircleIcon, ExternalLinkIcon, CloudUploadIcon, LayoutGrid as GridIcon, Share2Icon } from 'lucide-react'
 import { ComponentProps } from 'react'
 import { useSearchParams } from 'react-router'
 
@@ -83,7 +83,7 @@ export function NavLinks({ className, ...props }: ComponentProps<'nav'>) {
           window.toggleSidebar()
         }}
       >
-        <FolderIcon className="mr-3 size-5" aria-hidden="true" />
+        <CloudUploadIcon className="mr-3 size-5" aria-hidden="true" />
         <T name="files" />
       </Button>
     </nav>


### PR DESCRIPTION
- Add share_token column to drive_share table in all backends
- Generate unique tokens on share creation, use for public access
- Update frontend to use share tokens instead of share IDs
- Add trash functionality to shared drive view
- Sync implementation across Go, Kotlin, Python, and Rust backends
- Update i18n translations (en, zh)