### PR TITLE
fix(api-py): require auth on /api/drive/* routes

### DIFF
--- a/api-py/app/handler/api.py
+++ b/api-py/app/handler/api.py
@@ -352,11 +352,11 @@ def auth() -> NoContent:
     return NO_CONTENT
 
 
-@api.before_request
-def check_permission() -> None:
-    if request.path.endswith('login'):
-        return
-
+def require_app_token() -> None:
+    """Validate the app token from the `token` cookie or a `Bearer` header;
+    raise 401 when it's missing or invalid. Shared by the notes (`api`) and
+    drive (`drive_bp`) blueprints so both enforce auth identically.
+    """
     token = request.cookies.get('token')
 
     if not token:
@@ -370,6 +370,13 @@ def check_permission() -> None:
 
     if not is_valid_password(token):
         unauthorized("invalid authorization token")
+
+
+@api.before_request
+def check_permission() -> None:
+    if request.path.endswith('login'):
+        return
+    require_app_token()
 
 
 # Helper functions

--- a/api-py/app/handler/drive.py
+++ b/api-py/app/handler/drive.py
@@ -62,9 +62,21 @@ from ..services.drive_upload import (
 )
 from ..services.drive_zip import zip_folder_iter, zip_nodes_iter
 from ..middleware import validate
+from .api import require_app_token
 from .drive_serve import serve_drive_blob
 
 drive_bp = Blueprint('drive', __name__)
+
+
+@drive_bp.before_request
+def require_auth() -> None:
+    """Every /api/drive/* route requires the app token, the same check the
+    notes API applies. The public share surface (/shared-files/*) is a
+    separate blueprint and stays unauthenticated by design.
+    """
+    if request.method == 'OPTIONS':  # let CORS preflight through
+        return
+    require_app_token()
 
 
 # ---------------------------------------------------------------------------

--- a/api-py/tests/conftest.py
+++ b/api-py/tests/conftest.py
@@ -7,6 +7,10 @@ from app.config import Config
 from app import create_app
 from app.extension import db as _db
 
+# The notes and drive APIs require MOTE_PASSWORD; pin it for tests so the value
+# the authenticated `client` fixture sends always matches what the app checks.
+os.environ.setdefault('MOTE_PASSWORD', 'foobar')
+
 
 @pytest.fixture(scope="session")
 def app():
@@ -45,7 +49,13 @@ def session(db):
 
 @pytest.fixture()
 def client(app, clean_drive):
-    return app.test_client()
+    c = app.test_client()
+    # /api/drive/* (and the notes API) require the app token; authenticate
+    # every request this client makes. /shared-files/* ignores it (public).
+    pw = os.getenv('MOTE_PASSWORD')
+    if pw:
+        c.environ_base['HTTP_AUTHORIZATION'] = f'Bearer {pw}'
+    return c
 
 
 @pytest.fixture()

--- a/api-py/tests/test_drive_handler.py
+++ b/api-py/tests/test_drive_handler.py
@@ -134,3 +134,18 @@ def test_ensure_path_route(client):
         '/api/drive/folders/ensure-path', json={'parent_id': None, 'path': '../up'}
     )
     assert rv.status_code == 400
+
+
+def test_drive_requires_auth(app, client):
+    # Unauthenticated request → 401 (the guard runs before the handler).
+    anon = app.test_client()
+    assert anon.get('/api/drive/list').status_code == 401
+    # The authenticated fixture client succeeds.
+    assert client.get('/api/drive/list').status_code == 200
+
+
+def test_shared_files_stays_public(app):
+    # The public share surface must NOT require the app token: an anonymous
+    # request reaches the handler (404 for a missing share, not 401).
+    anon = app.test_client()
+    assert anon.get('/shared-files/nonexistent').status_code == 404


### PR DESCRIPTION
## Pre-existing security gap

In **api-py only**, the `drive_bp` blueprint (`/api/drive/*`) had no `before_request` guard, no decorator, no interceptor — all 27 routes (list, download, **delete, purge**, copy, star, …) were reachable **without any token**. The other editions all gate this surface:

- api-go → `SimpleAuthCheck` middleware on `/api/*`
- api-rs → `check_access` layer wrapping `/drive`
- api-kt → `DriveApiController` is `@AuthRequired(true)`
- **api-py → nothing** ❌ (this fix)

It predates the drive-feature work; the recent port faithfully followed the existing (missing) convention, so the new mutating routes inherited the same exposure.

## Fix

- Factor the token check out of the notes blueprint's `check_permission` into a shared `require_app_token()` (token from the `token` cookie or a `Bearer` header → `is_valid_password` → else 401), and apply it via `drive_bp.before_request`, skipping CORS `OPTIONS` preflight.
- The public share surface `/shared-files/*` is a **separate blueprint** and stays unauthenticated **by design** (matches every other edition's public share router) — only a share's own optional password applies there.

## Tests

- The shared HTTP `client` fixture now sends the app token, so the existing drive route tests keep exercising the endpoints. `MOTE_PASSWORD` is pinned in `conftest` so the sent token always matches what the app checks.
- New guards: an unauthenticated `GET /api/drive/list` returns **401** (authenticated → **200**), and an anonymous `GET /shared-files/<token>` still reaches the handler (**404** for a missing share, not 401) — proving the guard doesn't over-reach.
- **116 → 118 passed, 0 failed.**

Targets `feat/api-py` (the Python edition's home branch), not `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)