### PR TITLE
fix(web): search results horizontal scrollbar + first card flush to top

### DIFF
--- a/frontend/src/views/main/search-page.tsx
+++ b/frontend/src/views/main/search-page.tsx
@@ -231,12 +231,17 @@ export function SearchPage() {
       {/* Body: results or empty-state */}
       {hasQuery ? (
         searchTerm ? (
-          <PostList
-            className="min-h-0 flex-1 overflow-y-auto px-3 py-2"
-            queryString={new URLSearchParams({ query: searchTerm }).toString()}
-            orderBy={orderBy}
-            ascending={asc}
-          />
+          // Padding lives on this wrapper, not on the virtuoso scroller: horizontal
+          // padding on the scroller makes its content overflow (spurious x-scrollbar),
+          // and the scroller doesn't honor top padding for its first item.
+          <div className="min-h-0 flex-1 overflow-hidden px-4 py-3">
+            <PostList
+              className="h-full overflow-x-hidden"
+              queryString={new URLSearchParams({ query: searchTerm }).toString()}
+              orderBy={orderBy}
+              ascending={asc}
+            />
+          </div>
         ) : (
           <div className="flex-1" />
         )


### PR DESCRIPTION
When a search has results, the panel showed a spurious **horizontal scrollbar** and the **first result card sat flush** against the order-by row.

**Cause:** the results padding was on the react-virtuoso scroller. Horizontal padding makes the scroller's `scrollWidth` exceed `clientWidth` (and it's `overflow-x: auto`), and virtuoso doesn't honor the scroller's top padding for its first item.

**Fix:** move the `px-4 py-3` inset onto a wrapper; the scroller now has no padding + `overflow-x-hidden`.

Verified on desktop: no x-scrollbar (`scrollWidth == clientWidth`), first card sits ~21px below the order row. `tsc` + `eslint` clean.

Note: the same fix should be cherry-picked to `feat/api-{py,kt,rs}` (they carry the redesign too).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9umod26vS3HqWAsunBWon