### PR TITLE
feat(web): style parent-post link as a quote pill

### DIFF
--- a/frontend/src/views/post/post-card.tsx
+++ b/frontend/src/views/post/post-card.tsx
@@ -105,15 +105,15 @@ export const PostCard = memo(function PostItem({
           />
         )}
         {post.parent && showParentLink && (
-          <footer className="mt-2 -ml-4 flex items-center">
+          <footer className="mt-3 flex items-center gap-1">
             <TruncateLink
-              className="max-w-full overflow-hidden"
+              className="flex-1"
               post={post.parent}
               maxLength={100}
               aria-label="see full post"
             />
             <Button
-              className="text-foreground/75! relative top-[1px] -mr-2 px-1!"
+              className="text-muted-foreground hover:text-foreground size-8 flex-none px-0! opacity-100 transition-opacity duration-150 md:opacity-0 md:group-hover/memo:opacity-100"
               size="sm"
               variant="ghost"
               title="detach from parent post"
@@ -130,7 +130,7 @@ export const PostCard = memo(function PostItem({
                 })
               }}
             >
-              <Unlink2Icon className="size-5 pr-1" aria-hidden="true" />
+              <Unlink2Icon className="size-4" aria-hidden="true" />
             </Button>
           </footer>
         )}

--- a/frontend/src/views/post/post-card.tsx
+++ b/frontend/src/views/post/post-card.tsx
@@ -113,7 +113,7 @@ export const PostCard = memo(function PostItem({
               aria-label="see full post"
             />
             <Button
-              className="text-muted-foreground hover:text-foreground size-8 flex-none px-0! opacity-100 transition-opacity duration-150 md:opacity-0 md:group-hover/memo:opacity-100"
+              className="text-muted-foreground hover:text-foreground size-8 flex-none px-0! opacity-100 transition-opacity duration-150 focus-visible:opacity-100 md:opacity-0 md:group-hover/memo:opacity-100 md:group-focus-within/memo:opacity-100"
               size="sm"
               variant="ghost"
               title="detach from parent post"

--- a/frontend/src/views/post/truncate-link.tsx
+++ b/frontend/src/views/post/truncate-link.tsx
@@ -1,4 +1,4 @@
-import { QuoteIcon } from 'lucide-react'
+import { TextQuoteIcon } from 'lucide-react'
 import { ComponentProps } from 'react'
 import { Location, useLocation } from 'react-router'
 
@@ -24,9 +24,10 @@ export function TruncateLink({ post, maxLength, className, ...props }: TruncateL
 
   return (
     <button
+      {...props}
       type="button"
       className={cx(
-        'bg-muted text-muted-foreground hover:bg-primary/10 hover:text-primary flex min-w-0 items-center gap-2 overflow-hidden rounded-md px-3 py-1.5 text-[12.5px] transition-colors',
+        'bg-muted text-muted-foreground hover:bg-primary/10 hover:text-primary focus-visible:ring-ring flex min-w-0 items-center gap-2 overflow-hidden rounded-md px-3 py-1.5 text-[12.5px] transition-colors focus-visible:ring-1 focus-visible:ring-offset-0 focus-visible:outline-none',
         className,
       )}
       onClick={() => {
@@ -39,10 +40,9 @@ export function TruncateLink({ post, maxLength, className, ...props }: TruncateL
           },
         })
       }}
-      {...props}
     >
-      <QuoteIcon className="size-3.5 flex-none opacity-70" aria-hidden="true" />
-      <span className="truncate">
+      <TextQuoteIcon className="size-3.5 flex-none opacity-70" aria-hidden="true" />
+      <span className="min-w-0 flex-1 truncate text-left">
         {post.content.replace(/(<([^>]+)>)/gi, ' ').substring(0, maxLength)}
       </span>
     </button>

--- a/frontend/src/views/post/truncate-link.tsx
+++ b/frontend/src/views/post/truncate-link.tsx
@@ -1,18 +1,21 @@
+import { QuoteIcon } from 'lucide-react'
 import { ComponentProps } from 'react'
 import { Location, useLocation } from 'react-router'
 
 import { cx } from '@/utils/css.ts'
 
-import { Button } from '@/components/button.tsx'
 import { useStableNavigate } from '@/components/router.tsx'
 
 import { Post } from './post-list.tsx'
 
-interface TruncateLinkProps extends ComponentProps<typeof Button> {
+interface TruncateLinkProps extends ComponentProps<'button'> {
   post: Post
   maxLength?: number
 }
 
+// A compact "quoted note" pill: the parent post's text with a leading quote
+// icon, muted by default and tinted with the primary color on hover. Clicking
+// it opens the parent post.
 export function TruncateLink({ post, maxLength, className, ...props }: TruncateLinkProps) {
   // NOTE: `useNavigate` hook causes waste rendering
   // https://github.com/remix-run/react-router/issues/7634
@@ -20,9 +23,12 @@ export function TruncateLink({ post, maxLength, className, ...props }: TruncateL
   const location = useLocation()
 
   return (
-    <Button
-      className={cx('h-8', className)}
-      variant="link"
+    <button
+      type="button"
+      className={cx(
+        'bg-muted text-muted-foreground hover:bg-primary/10 hover:text-primary flex min-w-0 items-center gap-2 overflow-hidden rounded-md px-3 py-1.5 text-[12.5px] transition-colors',
+        className,
+      )}
       onClick={() => {
         const bg = (location.state as { backgroundLocation?: Location } | null)?.backgroundLocation
         void navigate(`/p/${String(post.id)}`, {
@@ -35,9 +41,10 @@ export function TruncateLink({ post, maxLength, className, ...props }: TruncateL
       }}
       {...props}
     >
-      <span className="max-w-full truncate">
+      <QuoteIcon className="size-3.5 flex-none opacity-70" aria-hidden="true" />
+      <span className="truncate">
         {post.content.replace(/(<([^>]+)>)/gi, ' ').substring(0, maxLength)}
       </span>
-    </Button>
+    </button>
   )
 }


### PR DESCRIPTION
Ports the prototype's `memo-quote` look to `PostCard`'s parent-post reference: a compact muted pill with a leading quote icon + the parent's text, tinted to the primary color on hover. The detach (unlink) action becomes a subtle icon button that reveals on hover.

`TruncateLink` (used only by `PostCard`) is refactored into the pill. Verified on desktop via the quote flow (default + hover). `tsc` + `eslint` clean.

Note: same as the other search/composer work — should be cherry-picked to `feat/api-{py,kt,rs}`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01R9umod26vS3HqWAsunBWon