### PR TITLE
feat(web): replace the Nocturne theme with Wisteria (violet)

### DIFF
--- a/designs/mote-redesign/Mote Redesign.html
+++ b/designs/mote-redesign/Mote Redesign.html
@@ -8,7 +8,7 @@
 <style>
 /* ============================================================
    Mote Redesign — 设计令牌
-   4 套主题（曦 dawn / 墨 ink / 青 celadon / 夜 nocturne）× 明暗
+   4 套主题（曦 dawn / 墨 ink / 青 celadon / 紫 wisteria）× 明暗
    令牌命名与 frontend/src/index.css 对齐，便于落地。
    ============================================================ */
 :root {
@@ -158,47 +158,47 @@
   --shadow-3: 0 4px 12px hsl(0 0% 0% / 0.38), 0 28px 60px -14px hsl(0 0% 0% / 0.6);
 }
 
-/* ---------- 夜 nocturne · 东京夜 靛蓝 + 玫瑰 ---------- */
-[data-color-theme="nocturne"][data-theme="light"] {
-  --background: hsl(228 32% 97%);
-  --foreground: hsl(231 38% 11%);
-  --card: hsl(228 45% 99.5%);
-  --card-2: hsl(228 26% 93%);
-  --muted-foreground: hsl(230 13% 44%);
-  --faint: hsl(230 10% 63%);
-  --border: hsl(228 18% 87%);
-  --border-strong: hsl(228 16% 78%);
-  --primary: hsl(231 62% 53%);
+/* ---------- 紫 wisteria · 紫藤薄暮 + 玫瑰 ---------- */
+[data-color-theme="wisteria"][data-theme="light"] {
+  --background: hsl(282 30% 97.5%);
+  --foreground: hsl(279 30% 12%);
+  --card: hsl(288 42% 99.5%);
+  --card-2: hsl(278 22% 93%);
+  --muted-foreground: hsl(278 12% 44%);
+  --faint: hsl(278 10% 63%);
+  --border: hsl(278 18% 88%);
+  --border-strong: hsl(278 16% 78%);
+  --primary: hsl(278 56% 52%);
   --primary-foreground: hsl(0 0% 100%);
-  --primary-tint: hsl(231 62% 53% / 0.08);
-  --primary-tint-2: hsl(231 62% 53% / 0.15);
-  --accent: hsl(340 62% 54%);
+  --primary-tint: hsl(278 56% 52% / 0.08);
+  --primary-tint-2: hsl(278 56% 52% / 0.15);
+  --accent: hsl(328 60% 55%);
   --destructive: hsl(4 72% 50%);
-  --glow-a: hsl(231 62% 70% / 0.15);
-  --glow-b: hsl(340 62% 70% / 0.11);
-  --radius: 9px;
-  --shadow-1: 0 1px 2px hsl(231 40% 10% / 0.04), 0 1px 1px hsl(231 40% 10% / 0.03);
-  --shadow-2: 0 1px 2px hsl(231 40% 10% / 0.05), 0 10px 24px -8px hsl(231 40% 10% / 0.11);
-  --shadow-3: 0 2px 6px hsl(231 40% 10% / 0.06), 0 24px 48px -12px hsl(231 40% 10% / 0.2);
+  --glow-a: hsl(278 66% 72% / 0.15);
+  --glow-b: hsl(328 66% 72% / 0.11);
+  --radius: 14px;
+  --shadow-1: 0 1px 2px hsl(279 40% 10% / 0.04), 0 1px 1px hsl(279 40% 10% / 0.03);
+  --shadow-2: 0 1px 2px hsl(279 40% 10% / 0.05), 0 10px 24px -8px hsl(279 40% 10% / 0.11);
+  --shadow-3: 0 2px 6px hsl(279 40% 10% / 0.06), 0 24px 48px -12px hsl(279 40% 10% / 0.2);
 }
-[data-color-theme="nocturne"][data-theme="dark"] {
-  --background: hsl(233 30% 10.5%);
-  --foreground: hsl(226 30% 80%);
-  --card: hsl(232 26% 14%);
-  --card-2: hsl(231 23% 18%);
-  --muted-foreground: hsl(226 16% 60%);
-  --faint: hsl(226 12% 44%);
-  --border: hsl(231 20% 21.5%);
-  --border-strong: hsl(231 18% 29%);
-  --primary: hsl(219 90% 71%);
-  --primary-foreground: hsl(233 42% 8%);
-  --primary-tint: hsl(219 90% 71% / 0.11);
-  --primary-tint-2: hsl(219 90% 71% / 0.19);
-  --accent: hsl(340 68% 68%);
+[data-color-theme="wisteria"][data-theme="dark"] {
+  --background: hsl(276 28% 11%);
+  --foreground: hsl(276 24% 84%);
+  --card: hsl(275 24% 14.5%);
+  --card-2: hsl(274 22% 18.5%);
+  --muted-foreground: hsl(276 14% 62%);
+  --faint: hsl(276 12% 44%);
+  --border: hsl(274 18% 22%);
+  --border-strong: hsl(274 16% 30%);
+  --primary: hsl(277 80% 74%);
+  --primary-foreground: hsl(276 45% 10%);
+  --primary-tint: hsl(277 80% 74% / 0.11);
+  --primary-tint-2: hsl(277 80% 74% / 0.19);
+  --accent: hsl(328 68% 70%);
   --destructive: hsl(4 78% 64%);
-  --glow-a: hsl(219 90% 42% / 0.2);
-  --glow-b: hsl(340 68% 42% / 0.12);
-  --radius: 9px;
+  --glow-a: hsl(278 78% 48% / 0.2);
+  --glow-b: hsl(328 60% 44% / 0.12);
+  --radius: 14px;
   --shadow-1: 0 1px 2px hsl(0 0% 0% / 0.28);
   --shadow-2: 0 2px 4px hsl(0 0% 0% / 0.32), 0 12px 28px -10px hsl(0 0% 0% / 0.52);
   --shadow-3: 0 4px 12px hsl(0 0% 0% / 0.4), 0 28px 60px -14px hsl(0 0% 0% / 0.62);

--- a/designs/mote-redesign/data.jsx
+++ b/designs/mote-redesign/data.jsx
@@ -6,7 +6,7 @@ const THEMES = [
   { id: "celadon", name: "青", ball: "linear-gradient(135deg, hsl(170 58% 34%) 50%, hsl(158 30% 93%) 50%)" },
   { id: "dawn", name: "曦", ball: "linear-gradient(135deg, hsl(216 78% 55%) 50%, hsl(40 30% 94%) 50%)" },
   { id: "ink", name: "墨", ball: "linear-gradient(135deg, hsl(9 68% 48%) 50%, hsl(30 12% 96%) 50%)" },
-  { id: "nocturne", name: "夜", ball: "linear-gradient(135deg, hsl(222 90% 68%) 50%, hsl(233 30% 14%) 50%)" },
+  { id: "wisteria", name: "紫", ball: "linear-gradient(135deg, hsl(278 70% 64%) 50%, hsl(276 28% 14%) 50%)" },
 ];
 
 // ---------- 笔记 ----------

--- a/designs/mote-redesign/设计说明.md
+++ b/designs/mote-redesign/设计说明.md
@@ -19,7 +19,7 @@
 | **青 celadon（默认）** | 青瓷苍绿 + 茶褐 | `hsl(170 58% 30%)` | 13px | moss / candy 合并 |
 | 曦 dawn | 晨光暖纸 + 蔚蓝 | `hsl(216 78% 49%)` | 11px | default |
 | 墨 ink | 无彩编辑部 + 朱砂 | `hsl(9 68% 46%)` | 6px | ink / blueprint 合并 |
-| 夜 nocturne | 东京夜靛蓝 + 玫瑰 | `hsl(231 62% 53%)` | 9px | fjord / sakura / aurora 合并 |
+| 紫 wisteria | 紫藤薄暮 + 玫瑰 | `hsl(278 56% 52%)` | 14px | nocturne / fjord / sakura / aurora 合并 |
 
 令牌命名与 `frontend/src/index.css` 对齐（`--background/--foreground/--card/--muted-foreground/--border/--primary/…`），
 新增：`--card-2`（悬浮/内嵌面）、`--faint`（第三级文字）、`--primary-tint(-2)`、`--shadow-1/2/3`、`--glow-a/b`。

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -14,16 +14,17 @@
     <title>mote</title>
     <script>
       ;(() => {
-        const colorThemes = ['celadon', 'dawn', 'ink', 'nocturne']
+        const colorThemes = ['celadon', 'dawn', 'ink', 'wisteria']
         const legacyColorThemes = {
           classic: 'celadon',
           moss: 'celadon',
           candy: 'celadon',
           voltage: 'celadon',
-          sakura: 'nocturne',
-          aurora: 'nocturne',
-          fjord: 'nocturne',
-          dune: 'nocturne',
+          nocturne: 'wisteria',
+          sakura: 'wisteria',
+          aurora: 'wisteria',
+          fjord: 'wisteria',
+          dune: 'wisteria',
           blueprint: 'ink',
           rouge: 'ink',
         }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -68,7 +68,7 @@
   }
 
   /* ------------------------------------------------------------------
-     主题：青 celadon（默认） / 曦 dawn / 墨 ink / 夜 nocturne，各配明暗。
+     主题：青 celadon（默认） / 曦 dawn / 墨 ink / 紫 wisteria，各配明暗。
      命名与旧版一致；青瓷做基础块（无 data-color-theme 时生效）。
      ------------------------------------------------------------------ */
 
@@ -239,59 +239,59 @@
     --theme-glow-b: 30 20% 30%;
   }
 
-  /* 夜 Nocturne — 东京夜靛蓝 + 玫瑰 */
-  [data-color-theme='nocturne'][data-theme='light'] {
-    --neutral: 228 22% 92%;
-    --neutral-foreground: 231 24% 22%;
-    --background: 228 32% 97%;
-    --foreground: 231 38% 11%;
-    --muted: 228 26% 93%;
-    --muted-foreground: 230 13% 44%;
-    --popover: 228 45% 99.5%;
-    --popover-foreground: 231 38% 11%;
-    --card: 228 45% 99.5%;
-    --card-foreground: 231 38% 11%;
-    --border: 228 18% 87%;
-    --input: 228 18% 83%;
-    --primary: 231 62% 53%;
+  /* 紫 Wisteria — 紫藤薄暮 + 玫瑰 */
+  [data-color-theme='wisteria'][data-theme='light'] {
+    --neutral: 276 20% 92%;
+    --neutral-foreground: 278 22% 22%;
+    --background: 282 30% 97.5%;
+    --foreground: 279 30% 12%;
+    --muted: 278 22% 93%;
+    --muted-foreground: 278 12% 44%;
+    --popover: 288 42% 99.5%;
+    --popover-foreground: 279 30% 12%;
+    --card: 288 42% 99.5%;
+    --card-foreground: 279 30% 12%;
+    --border: 278 18% 88%;
+    --input: 278 18% 84%;
+    --primary: 278 56% 52%;
     --primary-foreground: 0 0% 100%;
-    --secondary: 228 26% 92%;
-    --secondary-foreground: 231 38% 14%;
-    --accent: 228 24% 91%;
-    --accent-foreground: 231 38% 12%;
+    --secondary: 278 22% 92.5%;
+    --secondary-foreground: 279 30% 15%;
+    --accent: 278 22% 91%;
+    --accent-foreground: 279 30% 12%;
     --destructive: 4 72% 50%;
     --destructive-foreground: 0 0% 100%;
-    --ring: 231 62% 53%;
-    --radius: 0.55rem;
-    --theme-glow-a: 231 62% 70%;
-    --theme-glow-b: 340 62% 70%;
+    --ring: 278 56% 52%;
+    --radius: 0.9rem;
+    --theme-glow-a: 278 66% 72%;
+    --theme-glow-b: 328 66% 72%;
   }
 
-  [data-color-theme='nocturne'][data-theme='dark'] {
-    --neutral: 232 26% 15%;
-    --neutral-foreground: 226 24% 76%;
-    --background: 233 30% 10.5%;
-    --foreground: 226 30% 80%;
-    --muted: 231 23% 18%;
-    --muted-foreground: 226 16% 60%;
-    --popover: 233 32% 9%;
-    --popover-foreground: 226 30% 86%;
-    --card: 232 26% 14%;
-    --card-foreground: 226 30% 80%;
-    --border: 231 20% 21.5%;
-    --input: 231 20% 26%;
-    --primary: 219 90% 71%;
-    --primary-foreground: 233 42% 8%;
-    --secondary: 231 23% 19%;
-    --secondary-foreground: 226 30% 80%;
-    --accent: 231 22% 22%;
-    --accent-foreground: 226 30% 88%;
+  [data-color-theme='wisteria'][data-theme='dark'] {
+    --neutral: 274 24% 16%;
+    --neutral-foreground: 276 20% 78%;
+    --background: 276 28% 11%;
+    --foreground: 276 24% 84%;
+    --muted: 274 22% 18.5%;
+    --muted-foreground: 276 14% 62%;
+    --popover: 276 30% 9.5%;
+    --popover-foreground: 276 24% 88%;
+    --card: 275 24% 14.5%;
+    --card-foreground: 276 24% 84%;
+    --border: 274 18% 22%;
+    --input: 274 18% 26%;
+    --primary: 277 80% 74%;
+    --primary-foreground: 276 45% 10%;
+    --secondary: 274 20% 19.5%;
+    --secondary-foreground: 276 24% 84%;
+    --accent: 274 20% 22.5%;
+    --accent-foreground: 276 24% 90%;
     --destructive: 4 78% 64%;
     --destructive-foreground: 0 0% 100%;
-    --ring: 219 90% 71%;
-    --radius: 0.55rem;
-    --theme-glow-a: 219 90% 42%;
-    --theme-glow-b: 340 68% 42%;
+    --ring: 277 80% 74%;
+    --radius: 0.9rem;
+    --theme-glow-a: 278 78% 48%;
+    --theme-glow-b: 328 60% 44%;
   }
 
   * {

--- a/frontend/src/lang/en.json
+++ b/frontend/src/lang/en.json
@@ -32,7 +32,7 @@
   "themeCeladon": "Celadon",
   "themeDawn": "Dawn",
   "themeInk": "Ink",
-  "themeNocturne": "Nocturne",
+  "themeWisteria": "Wisteria",
   "today": "Today",
   "yesterday": "Yesterday",
   "small": "small",

--- a/frontend/src/lang/zh.json
+++ b/frontend/src/lang/zh.json
@@ -32,7 +32,7 @@
   "themeCeladon": "青瓷",
   "themeDawn": "晨曦",
   "themeInk": "纸墨",
-  "themeNocturne": "东京夜",
+  "themeWisteria": "紫藤",
   "today": "今天",
   "yesterday": "昨天",
   "small": "较小",

--- a/frontend/src/views/sidebar/theme-toggle.tsx
+++ b/frontend/src/views/sidebar/theme-toggle.tsx
@@ -26,9 +26,9 @@ export const COLOR_THEMES = [
     swatches: ['28 10% 90%', '9 68% 46%', '24 6% 8%'],
   },
   {
-    id: 'nocturne',
-    labelKey: 'themeNocturne',
-    swatches: ['228 26% 90%', '219 90% 71%', '233 30% 10.5%'],
+    id: 'wisteria',
+    labelKey: 'themeWisteria',
+    swatches: ['278 24% 90%', '278 64% 58%', '276 28% 11%'],
   },
 ] as const satisfies readonly {
   id: string
@@ -43,10 +43,11 @@ const LEGACY_COLOR_THEME_MAP: Record<string, ColorTheme> = {
   moss: 'celadon',
   candy: 'celadon',
   voltage: 'celadon',
-  sakura: 'nocturne',
-  aurora: 'nocturne',
-  fjord: 'nocturne',
-  dune: 'nocturne',
+  nocturne: 'wisteria',
+  sakura: 'wisteria',
+  aurora: 'wisteria',
+  fjord: 'wisteria',
+  dune: 'wisteria',
   blueprint: 'ink',
   rouge: 'ink',
 }

--- a/frontend/src/views/sidebar/theme-toggle.tsx
+++ b/frontend/src/views/sidebar/theme-toggle.tsx
@@ -28,7 +28,7 @@ export const COLOR_THEMES = [
   {
     id: 'wisteria',
     labelKey: 'themeWisteria',
-    swatches: ['278 24% 90%', '278 64% 58%', '276 28% 11%'],
+    swatches: ['278 24% 90%', '278 56% 52%', '276 28% 11%'],
   },
 ] as const satisfies readonly {
   id: string


### PR DESCRIPTION
## What & why

`晨曦 Dawn` (azure, hue 216°) and `东京夜 Nocturne` (indigo, hue 231°) were both blue-family primaries only ~15° apart, so the two themes looked nearly identical. This replaces the redundant Nocturne with a new violet theme, **`紫藤 Wisteria`** (hue ~278°), filling the empty purple slot on the color wheel — now 62° away from Dawn.

The palette follows the same token structure and lightness ladder as the other three themes, just rotated to violet:
- Light primary `hsl(278 56% 52%)` (white text ≈ 5.4:1 contrast), dark primary `hsl(277 80% 74%)`
- Rose accent + glow (~328°) for a "wisteria at dusk" feel, radius `0.9rem`

The palette (green 170° / azure 216° / cinnabar 9° / **violet 278°**) is now spread across the wheel instead of doubling up on blue.

## Migration

Existing `nocturne` selections — and its legacy aliases (`sakura` / `aurora` / `fjord` / `dune`) — now map to `wisteria` in both the React store and the pre-hydration script, so nobody's saved theme breaks.

## Changes

- `frontend/src/index.css` — new light/dark Wisteria token blocks
- `frontend/src/views/sidebar/theme-toggle.tsx` — picker entry + legacy migration map
- `frontend/src/lang/{en,zh}.json` — `themeNocturne` → `themeWisteria` (紫藤 / Wisteria)
- `frontend/index.html` — pre-hydration theme script
- `designs/mote-redesign/*` — prototype synced to match

## Test plan

- [x] `tsc --noEmit`, `eslint`, and `jest` pass
- [ ] Settings → Theme → pick 紫藤 / Wisteria; verify light + dark
- [ ] Confirm an existing `nocturne` selection auto-migrates to Wisteria

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121ehWyaVT54W2ED4vJbt5x
