### PR TITLE
feat(web): submit the composer with Cmd/Ctrl+Enter

### DIFF
--- a/frontend/e2e/post.test.js
+++ b/frontend/e2e/post.test.js
@@ -11,3 +11,13 @@ test('can create a post and delete it', async ({ page }) => {
   await createPost(page, 'wakeup neo')
   await deletePost(page, 'wakeup neo')
 })
+
+test('can submit a post with the Cmd/Ctrl+Enter shortcut', async ({ page }) => {
+  await page.goto('/')
+  await page.fill('[role="textbox"]', 'submit via shortcut')
+  // `ControlOrMeta` resolves to Meta on macOS and Control elsewhere,
+  // matching the editor's `isCtrlKey` handling.
+  await page.locator('[role="textbox"]').press('ControlOrMeta+Enter')
+  await expect(page.locator('div > p:has-text("submit via shortcut")').first()).toBeVisible()
+  await deletePost(page, 'submit via shortcut')
+})

--- a/frontend/src/components/editor/editor.tsx
+++ b/frontend/src/components/editor/editor.tsx
@@ -43,9 +43,12 @@ import {
   toggleMark,
 } from './utils'
 
-export interface EditorProps extends Omit<TextareaHTMLAttributes<HTMLDivElement>, 'onChange'> {
+export interface EditorProps
+  extends Omit<TextareaHTMLAttributes<HTMLDivElement>, 'onChange' | 'onSubmit'> {
   initialValue: SlateElement[]
   onChange: (value: SlateElement[]) => void
+  // Invoked when the user submits with Cmd/Ctrl+Enter.
+  onSubmit?: () => void
   autoFocus?: boolean
   autoFocusEnd?: boolean
   tags?: string[]
@@ -84,6 +87,7 @@ declare module 'slate-react' {
 export function MbEditor({
   initialValue,
   onChange,
+  onSubmit,
   autoFocus = true,
   autoFocusEnd = false,
   tags = [],
@@ -254,13 +258,25 @@ export function MbEditor({
             return
           }
 
+          // Enter: submit on Cmd/Ctrl+Enter, soft line break on Shift+Enter.
+          // A bare Enter falls through to Slate's default (splits the block).
+          // Skip if another handler already consumed it (e.g. the hashtag
+          // autocomplete confirming a tag) so we don't submit mid-selection.
+          if (event.key === 'Enter' && !event.defaultPrevented) {
+            if (isCtrlKey(event)) {
+              event.preventDefault()
+              onSubmit?.()
+              return
+            }
+            if (event.shiftKey) {
+              event.preventDefault()
+              editor.insertText('\n')
+              return
+            }
+          }
+
           if (isCtrlKey(event)) {
             switch (event.key) {
-              case `Enter`: {
-                event.preventDefault()
-                editor.insertText('\n')
-                break
-              }
               case '.':
               case '`': {
                 event.preventDefault()

--- a/frontend/src/views/editor/editor.tsx
+++ b/frontend/src/views/editor/editor.tsx
@@ -3,6 +3,7 @@ import { ComponentProps, ReactNode, useCallback, useEffect, useMemo, useRef, use
 import { Element as SlateElement, Node as SlateNode, Text as SlateText } from 'slate'
 import useSWR from 'swr'
 
+import { IS_APPLE } from '@/utils/browser.ts'
 import { cx } from '@/utils/css.ts'
 import { useEvent } from '@/utils/hooks/use-event.ts'
 import { textToHtml } from '@/utils/text.ts'
@@ -23,6 +24,8 @@ import { ListMutator, PostMutator, postActions as actions } from '../actions.ts'
 import { Post } from '../post/post-list.tsx'
 import { Tag } from '../tag/tag-list.tsx'
 import { ToolBar, ToolButton } from './toolbar.tsx'
+
+const submitShortcutHint = IS_APPLE ? '⌘ + Enter' : 'Ctrl + Enter'
 
 interface PostEditorProps extends ComponentProps<'div'> {
   post: Partial<Post>
@@ -86,6 +89,12 @@ export function PostEditor({
     }),
   )
 
+  // Shared submit action for both the button and the Cmd/Ctrl+Enter shortcut.
+  const submit = useEvent(() => {
+    if (submitting || empty) return
+    void handleSubmit(toHtml({ children: trimTrailingEmptyParagraphs(value), type: '' }), images)
+  })
+
   const handleCancel = () => {
     afterCancel?.()
     localStorage.removeItem(draftKey)
@@ -105,6 +114,7 @@ export function PostEditor({
         uploadImage={uploadImage}
         onChange={setValue}
         onBlur={saveDraft}
+        onSubmit={submit}
       >
         <ImageGrid
           ref={imageGridRef}
@@ -149,14 +159,10 @@ export function PostEditor({
             variant="primary"
             type="submit"
             aria-label="submit"
+            title={submitShortcutHint}
             disabled={submitting || empty}
             style={{ opacity: submitting || empty ? 0.65 : 1 }}
-            onClick={() => {
-              void handleSubmit(
-                toHtml({ children: trimTrailingEmptyParagraphs(value), type: '' }),
-                images,
-              )
-            }}
+            onClick={submit}
           >
             <T name="submit" />
           </Button>


### PR DESCRIPTION
## What & why

The composer could only be submitted by clicking the button. This adds a keyboard shortcut: **⌘/Ctrl+Enter submits** (works for a new note, inline edit, and reply).

⌘/Ctrl+Enter was already bound to insert a soft line break, so it moves to the more conventional **Shift+Enter**; a bare Enter still starts a new block.

| Key | Action |
| --- | --- |
| `Enter` | New paragraph (unchanged) |
| `Shift + Enter` | Soft line break `\n` (was ⌘/Ctrl+Enter) |
| `⌘/Ctrl + Enter` | **Submit** (new) |

## Notes

- `MbEditor` gains an optional `onSubmit` prop; `PostEditor` shares one submit action between the button and the shortcut.
- No-ops while submitting or when the composer is empty (same guard as the disabled button).
- Guards on `event.defaultPrevented`, so ⌘/Ctrl+Enter while the `#tag` autocomplete is open picks the tag instead of *both* picking and submitting.
- Platform-aware tooltip on the submit button (`⌘ + Enter` on macOS, `Ctrl + Enter` elsewhere) for discoverability.
- Scoped to the focused editor, so with two composers open only the active one submits.

## Changes

- `frontend/src/components/editor/editor.tsx` — Enter handling + `onSubmit` prop
- `frontend/src/views/editor/editor.tsx` — shared submit action + tooltip
- `frontend/e2e/post.test.js` — submit-via-shortcut e2e test

## Test plan

- [x] `tsc --noEmit`, `eslint`, and `jest` (22 tests) pass
- [ ] `npm run playwright` (needs the dev server + backend on `:3000`)
- [ ] Manually: type a note → ⌘/Ctrl+Enter posts; Shift+Enter inserts a soft break; empty + ⌘/Ctrl+Enter does nothing

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0121ehWyaVT54W2ED4vJbt5x
