### PR TITLE
fix(post): correct memo fold mask and scroll-to-position bugs

### DIFF
--- a/frontend/src/views/post/collapsible.tsx
+++ b/frontend/src/views/post/collapsible.tsx
@@ -47,17 +47,22 @@ export function CollapsibleContent({
   useCodeBlockEnhancer(ref)
 
   const toggleCollapsed = () => {
-    const nextCollapsed = !collapsed
-    setCollapsed(nextCollapsed)
+    if (!collapsable) return
 
-    requestIdleCallback(() => {
-      if (nextCollapsed) {
-        scrollIntoView()
-        expandedItems.delete(post.id)
-      } else {
-        expandedItems.add(post.id)
-      }
-    })
+    const nextCollapsed = !collapsed
+
+    if (nextCollapsed) {
+      // Fold: pull the memo up to the top of the list so it stays in view. Do
+      // this BEFORE collapsing, while the virtual list's size cache still
+      // matches the DOM — scrolling after the height changes lands at the wrong
+      // spot, because the cache is only updated (async) once the item resizes.
+      scrollIntoView()
+      expandedItems.delete(post.id)
+    } else {
+      expandedItems.add(post.id)
+    }
+
+    setCollapsed(nextCollapsed)
   }
 
   return (

--- a/frontend/src/views/post/post-list.tsx
+++ b/frontend/src/views/post/post-list.tsx
@@ -88,7 +88,17 @@ export const PostList = memo(function PostList({
   }, [queryString, orderBy, ascending])
 
   const scrollItemIntoView = useCallback((index: number) => {
-    listHandle.current.scrollIntoView({ index })
+    // Align the item's top to the viewport top. Used when folding a memo:
+    // Virtuoso already re-anchors a large collapsing item to the top, but its
+    // native compensation lands a little too high (clipping the card). Forcing a
+    // clean top-align keeps the folded memo fully visible. We override
+    // `calculateViewLocation` because the default also aligns the item's
+    // *bottom*, which — with the stale (still-expanded) height mid-collapse —
+    // scrolled to a jarring, wrong position.
+    listHandle.current.scrollIntoView({
+      index,
+      calculateViewLocation: ({ locationParams }) => ({ ...locationParams, align: 'start' }),
+    })
   }, [])
 
   const isMainList = !queryString?.includes('parent_id')


### PR DESCRIPTION
## Summary

Fixes two bugs in the memo collapse feature (`/memo` feed).

### Bug 1 — spurious mask on non-collapsible memos
Double-clicking a memo whose content fits (doesn't exceed `MAX_POST_HEIGHT`) still toggled `collapsed`, applying the `clamp-mask` gradient + `max-height` at the bottom of content that didn't need folding. The fallback toggle button was already gated behind `collapsable`, but the double-click path wasn't.

**Fix:** `toggleCollapsed` now returns early when the memo isn't `collapsable`.

### Bug 2 — folding a long memo scrolls to a weird position
`toggleCollapsed` did `setCollapsed(true)` and then, inside `requestIdleCallback`, called Virtuoso's `scrollIntoView({ index })`. Virtuoso computes the scroll target from its **internal size cache** (`offsetTree`/`sizeTree`), which its `ResizeObserver` only updates **after** the item's height changes. So the scroll fired mid-collapse against the **stale, still-expanded height**, and the default alignment (which also aligns the item's *bottom*) overshot to a seemingly random spot.

**Fix (two parts):**
- `collapsible.tsx`: scroll **before** `setCollapsed`, while the size cache still matches the DOM; update the persisted-expand set synchronously (dropped the flaky `requestIdleCallback`).
- `post-list.tsx`: override `calculateViewLocation` to cleanly align the item's **top** to the viewport top. This depends only on the item's top offset (independent of its own height), so it stays correct through the resize and avoids the default's bottom-alignment overshoot.

Folding now lands the memo cleanly at the top of the list, fully visible, from any scroll position.

## Verification
Reproduced against the real app (dev server + stubbed posts API driven by Playwright):

| | Original | Fixed |
|---|---|---|
| Fold, header visible | jumps ~−271px, header 192→462 (weird) | header lands cleanly at list top |
| Fold, scrolled deep into content | ~−699px wild scroll / memo lost | memo pulled to top, fully visible |
| Fold across 8 scroll positions | position-dependent, inconsistent | consistent: collapsed + visible every time |
| Double-click short memo | mask applied ❌ | no mask ✅ |

- `tsc --noEmit` clean, eslint clean on both files, all 22 Jest unit tests pass.

## Note
Folding intentionally scrolls the memo to the top of the list (the original code already scrolled on fold, and Virtuoso re-anchors a large collapsing item to the top on its own). "Collapse perfectly in place" would mean fighting the virtual list's compensation, which is fragile — happy to pursue that instead if preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NuP983hrvAAXgU41dHapaM